### PR TITLE
feat: implement event selection wizard for register sale flow

### DIFF
--- a/src/app/buyers-list/BuyersList.module.css
+++ b/src/app/buyers-list/BuyersList.module.css
@@ -9,19 +9,28 @@
   width: 100%;
 }
 
-.titleSection {
-  flex: 1;
+.stickyHeader {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: var(--color-bg-primary);
+  padding-top: var(--space-xl);
+  margin-top: calc(var(--space-xl) * -1);
+  padding-bottom: var(--space-md);
+  margin-bottom: var(--space-md);
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s;
 }
 
-/* Action Bar - sin card: busqueda y filtros sobre el background */
+/* Action Bar */
 .actionBar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--space-xl);
   gap: var(--space-lg);
   padding: 0;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .leftSection {
@@ -30,6 +39,7 @@
   align-items: center;
   flex: 1;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .rightSection {
@@ -37,34 +47,10 @@
   align-items: center;
 }
 
-.assignButton {
-  background-color: var(--color-white);
-  color: var(--color-bg-primary);
-  border: none;
-  border-radius: var(--radius-md);
-  padding: var(--space-md) var(--space-xl);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all var(--transition-base);
-}
-
-.assignButton:hover {
-  background-color: var(--color-gray-900);
-  color: var(--color-bg-primary);
-}
-
-.assignButton:active {
-  transform: translateY(1px);
-}
-
 .searchContainer {
   position: relative;
-  flex: 1;
-  max-width: 400px;
+  flex: 1 1 300px;
+  min-width: 250px;
 }
 
 .searchIcon {
@@ -101,11 +87,6 @@
   background-color: var(--color-bg-tertiary);
 }
 
-.searchInput::placeholder {
-  color: var(--color-text-tertiary);
-  font-size: var(--font-size-base);
-}
-
 .statusFilter {
   min-width: 180px;
   flex: 1;
@@ -121,6 +102,7 @@
   gap: 20px;
   align-items: center;
   flex: 1;
+  flex-wrap: wrap;
 }
 
 /* Table Container */
@@ -152,7 +134,6 @@
   letter-spacing: 0.05em;
 }
 
-/* Header with Counter */
 .headerWithCounter {
   display: flex;
   align-items: center;
@@ -173,22 +154,61 @@
   text-align: center;
 }
 
-.table th:nth-child(1) {
-  width: 60px; /* Checkbox */
+/* === NORMALIZED COLUMN SPACING === */
+/* Consistent padding across all columns */
+.table th,
+.tableRow td {
+  padding: 16px 12px;
 }
 
-.table th:nth-child(2) {
-  width: 40%; /* Comprador name + phone */
+/* Column-specific padding for consistency - Higher specificity */
+.table th:nth-child(1),
+.tableRow td:nth-child(1),
+.table th.checkboxColumn,
+.tableRow td.checkboxColumn {
+  width: 60px !important;
+  min-width: 60px !important;
+  max-width: 60px !important;
+  padding: 12px 8px 12px 4px !important;
+  text-align: center !important;
+  vertical-align: middle !important;
 }
 
-.table th:nth-child(3) {
-  width: 40%; /* Evento Asignado */
+.table th:nth-child(2),
+.tableRow td:nth-child(2) {
+  padding: 16px 12px !important;
+  vertical-align: middle !important;
 }
 
-.table th:nth-child(4) {
-  width: 20%; /* Estado */
+.table th:nth-child(3),
+.tableRow td:nth-child(3) {
+  padding: 16px 12px !important;
+  vertical-align: middle !important;
 }
 
+.table th:nth-child(4),
+.tableRow td:nth-child(4),
+.table th.actionsColumn,
+.tableRow td.actionsColumn {
+  padding: 16px 20px 16px 12px !important;
+  text-align: center !important;
+  vertical-align: middle !important;
+  overflow: visible !important;
+}
+
+.checkboxColumn {
+  width: 60px !important;
+  min-width: 60px !important;
+  max-width: 60px !important;
+  text-align: center;
+}
+
+.checkbox {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
 
 .tableRow {
   border-bottom: 1px solid var(--color-border-light);
@@ -200,16 +220,13 @@
   background: var(--color-bg-tertiary);
 }
 
-.tableRow:last-child {
-  border-bottom: none;
-}
-
 .tableRowInactive {
   color: var(--color-text-tertiary);
+  background-color: rgba(239, 68, 68, 0.08) !important;
 }
 
 .tableRowInactive:hover {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(239, 68, 68, 0.12) !important;
 }
 
 .tableRowInactive .buyerInfo,
@@ -224,49 +241,10 @@
 }
 
 .tableRow td {
-  vertical-align: middle;
-  word-wrap: break-word;
-  overflow: visible;
-}
-
-/* === NORMALIZED COLUMN SPACING === */
-/* Consistent padding across all columns */
-.table th,
-.tableRow td {
   padding: 16px 12px;
+  vertical-align: middle;
 }
 
-/* Checkbox column specific styling */
-.table th.checkboxColumn,
-.tableRow td.checkboxColumn {
-  width: 60px !important;
-  min-width: 60px !important;
-  max-width: 60px !important;
-  padding: 12px 8px 12px 4px !important;
-  text-align: center !important;
-  vertical-align: middle !important;
-}
-
-/* Column-specific padding for consistency */
-.table th:nth-child(2),
-.tableRow td:nth-child(2) {
-  padding: 16px 12px !important;
-  vertical-align: middle !important;
-}
-
-.table th:nth-child(3),
-.tableRow td:nth-child(3) {
-  padding: 16px 12px !important;
-  vertical-align: middle !important;
-}
-
-.table th:nth-child(4),
-.tableRow td:nth-child(4) {
-  padding: 16px 12px !important;
-  vertical-align: middle !important;
-}
-
-/* Buyer Info */
 .buyerInfo {
   display: flex;
   flex-direction: column;
@@ -285,7 +263,6 @@
   font-size: var(--font-size-sm);
 }
 
-/* Event Info */
 .eventInfo {
   display: flex;
   flex-direction: column;
@@ -295,7 +272,6 @@
   font-weight: var(--font-weight-medium);
   color: var(--color-text-primary);
   font-size: 15px;
-  line-height: 1.3;
 }
 
 .noEvent {
@@ -305,183 +281,404 @@
   font-style: italic;
 }
 
-/* Toggle Switch */
-.switchWrapper {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.switchContainer {
-  position: relative;
-  display: inline-block;
-  width: 44px;
-  height: 24px;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.switchInput {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.switchSlider {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: var(--color-gray-300);
-  border-radius: 24px;
-  transition: all var(--transition-slow);
-}
-
-.switchSlider::before {
-  content: '';
-  position: absolute;
-  height: 18px;
-  width: 18px;
-  left: 3px;
-  bottom: 3px;
-  background-color: var(--color-white);
-  border-radius: 50%;
-  transition: all var(--transition-slow);
-  box-shadow: var(--shadow-sm);
-}
-
-.switchInput:checked + .switchSlider {
-  background-color: var(--color-success);
-}
-
-.switchInput:not(:checked) + .switchSlider {
-  background-color: var(--color-error);
-}
-
-.switchInput:checked + .switchSlider::before {
-  transform: translateX(20px);
-}
-
-.switchContainer:hover .switchSlider {
-  opacity: 0.9;
-}
-
-.switchInput:checked:focus + .switchSlider {
-  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.2);
-}
-
-.switchInput:not(:checked):focus + .switchSlider {
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
-}
-
-.switchLabel {
-  font-size: 15px;
-  font-weight: 700;
-  white-space: nowrap;
-  user-select: none;
-}
-
-.switchLabelActive {
-  color: var(--color-success);
-  font-weight: var(--font-weight-bold);
-}
-
-.switchLabelInactive {
-  color: var(--color-text-tertiary);
-  font-weight: var(--font-weight-bold);
-}
-
-/* Checkbox Column - Unified styles */
-.checkboxColumn {
-  width: 60px !important;
-  min-width: 60px !important;
-  max-width: 60px !important;
+.actionsColumn {
+  width: 15%;
   text-align: center;
 }
 
-.checkbox {
-  width: 18px;
-  height: 18px;
-  accent-color: var(--color-primary);
-  cursor: pointer;
-  vertical-align: middle;
-  margin: 0;
-}
-
-.checkbox:disabled {
-  cursor: not-allowed;
-  opacity: 0.4;
-}
-
-/* Checkbox Wrapper and Tooltip */
-.checkboxWrapper {
+.desktopMenuContainer {
   position: relative;
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  vertical-align: middle;
 }
 
-.checkboxTooltip {
+.desktopMenuButton {
+  background: none;
+  border: none;
+  padding: 8px;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+}
+
+.desktopMenuDropdown {
   position: absolute;
   top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  background-color: #1C1C1E;
-  color: var(--color-text-primary);
-  padding: 6px 10px;
-  border-radius: var(--radius-sm);
-  font-size: var(--font-size-xs);
-  white-space: nowrap;
-  opacity: 0;
-  visibility: hidden;
-  transition: all 0.2s;
-  pointer-events: none;
+  right: 0;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
   z-index: 100;
-  margin-top: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  min-width: 180px;
 }
 
-.checkboxWrapper:has(input:disabled):hover .checkboxTooltip {
-  opacity: 1;
-  visibility: visible;
+.desktopMenuItem {
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  color: var(--color-text-primary);
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-.checkboxPlaceholder {
-  width: 18px;
-  height: 18px;
-}
-
-/* Empty State */
 .emptyState {
   text-align: center;
   padding: 60px 20px;
+}
+
+/* Mobile Media Queries and Overrides */
+@media (max-width: 768px) {
+  .header {
+    margin-bottom: var(--space-lg);
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-md);
+  }
+
+  .titleSection,
+  .headerActions,
+  .headerActions button {
+    width: 100%;
+  }
+
+  .actionBar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-md);
+  }
+
+  .leftSection {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-sm);
+    width: 100%;
+  }
+
+  .searchContainer {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .filtersGroupDesktop {
+    display: none !important;
+  }
+
+  .filtersTriggerMobile {
+    display: flex !important;
+  }
+
+  .tableContainer {
+    display: none !important;
+  }
+
+  .mobileListContainer {
+    display: flex !important;
+    padding-bottom: 80px;
+  }
+
+  .assignStickyBar {
+    display: flex !important;
+  }
+}
+
+/* Mobile Specific Components */
+.filtersTriggerMobile {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 var(--space-sm);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
   color: var(--color-text-secondary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
 }
 
-.emptyState svg {
-  margin-bottom: var(--space-md);
+.assignStickyBar {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 200;
+  padding: var(--space-md);
+  padding-bottom: max(var(--space-md), env(safe-area-inset-bottom));
+  background-color: var(--color-bg-primary);
+  border-top: 1px solid var(--color-border-light);
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  box-sizing: border-box;
 }
 
-.emptyState h3 {
+.assignStickyCancel {
+  min-height: 44px;
+  padding: var(--space-md) var(--space-lg);
+  background: transparent;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-xl);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+.assignStickyPrimary {
+  flex: 1;
+  min-height: 44px;
+  padding: var(--space-md) var(--space-lg);
+  background-color: #E5E5EA;
+  color: var(--color-bg-primary);
+  border: none;
+  border-radius: var(--radius-xl);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.assignStickyPrimary:hover {
+  background-color: #D1D1D6;
+}
+
+.assignStickyPrimary:active {
+  transform: scale(0.98);
+}
+
+.sheetOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.sheetPanel {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 301;
+  max-height: 70vh;
+  overflow-y: auto;
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.2);
+  padding: var(--space-lg);
+  padding-bottom: max(var(--space-xl), env(safe-area-inset-bottom));
+  animation: sheetSlideUp 0.3s ease-out;
+}
+
+@keyframes sheetSlideUp {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+.sheetHandle {
+  width: 40px;
+  height: 4px;
+  margin: 0 auto var(--space-md);
+  background: var(--color-border);
+  border-radius: 2px;
+}
+
+.sheetTitle {
+  margin: 0 0 var(--space-lg);
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
-  margin: 0 0 var(--space-xs) 0;
   color: var(--color-text-primary);
 }
 
-.emptyState p {
+.sheetFilters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+  margin-bottom: var(--space-xl);
+}
+
+.sheetFilterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.sheetFilterLabel {
   font-size: var(--font-size-sm);
-  margin: 0;
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-secondary);
 }
 
+.sheetFilterOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
 
-/* Responsive Design - Solo Desktop */
-@media (max-width: 768px) {
-  /* Ocultar toda la página en mobile */
-  .pageContainer {
-    display: none !important;
-  }
+.sheetFilterOption,
+.sheetFilterOptionActive {
+  min-height: 44px;
+  padding: 0 var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-light);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+.sheetFilterOptionActive {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+}
+
+.sheetApply {
+  width: 100%;
+  min-height: 48px;
+  background: var(--color-white);
+  color: var(--color-bg-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.sheetApply:hover {
+  background: var(--color-gray-900);
+  color: var(--color-bg-primary);
+}
+
+.sheetApply:active {
+  transform: scale(0.98);
+}
+
+.mobileListContainer {
+  display: none;
+  flex-direction: column;
+  gap: 0;
+  padding: 0 var(--space-md);
+}
+
+.mobileListRow {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md);
+  padding: var(--space-md) 0;
+  min-height: 72px;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.mobileRowSelected {
+  background: var(--color-bg-tertiary);
+}
+
+.mobileRowInactive {
+  opacity: 0.6;
+  background-color: rgba(239, 68, 68, 0.08) !important;
+}
+
+.mobileRowCheckbox {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.mobileCheckbox {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--color-primary);
+}
+
+.mobileRowMain {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mobileRowTop {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.mobileRowName {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobileRowPhone,
+.mobileRowEventLine {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.mobileMenuContainer {
+  position: relative;
+}
+
+.mobileMenuButton {
+  background: none;
+  border: none;
+  padding: 8px;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+}
+
+.mobileMenuDropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 10;
+  min-width: 150px;
+}
+
+.mobileMenuItem {
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }

--- a/src/app/buyers-list/page.tsx
+++ b/src/app/buyers-list/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import { Buyer, Event, StatusFilter } from '@/types/models';
+import { Buyer, Event, Seller, StatusFilter } from '@/types/models';
 import { STATUS_OPTIONS } from '@/constants';
-import { MOCK_BUYERS, MOCK_EVENTS } from '@/mocks/data';
+import { MOCK_BUYERS, MOCK_EVENTS, MOCK_SELLERS } from '@/mocks/data';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import CustomDropdown from '@/components/CustomDropdown';
 import styles from './BuyersList.module.css';
 
@@ -11,17 +12,39 @@ export default function BuyersList() {
   // State
   const [buyers, setBuyers] = useState<Buyer[]>(MOCK_BUYERS);
   const [events, setEvents] = useState<Event[]>(MOCK_EVENTS);
-  
+  const [sellers] = useState<Seller[]>(MOCK_SELLERS);
+
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-  const [eventFilter, setEventFilter] = useState<string>('all');
+  // Initialize with the first active event if available
+  const [eventFilter, setEventFilter] = useState<string>(() => {
+    const active = MOCK_EVENTS.filter(e => e.status === 'active');
+    return active.length > 0 ? active[0].id : '';
+  });
   const [selectedBuyers, setSelectedBuyers] = useState<string[]>([]);
-  
+
+  // Mobile menu state
+  const [mobileMenuOpen, setMobileMenuOpen] = useState<string | null>(null);
+  // Desktop context menu state
+  const [desktopMenuOpen, setDesktopMenuOpen] = useState<string | null>(null);
+  // Mobile-only: Filtros sheet, Assign sticky + sheet
+  const [filtersSheetOpen, setFiltersSheetOpen] = useState(false);
+
+  // Custom hooks
+  const isDesktop = useMediaQuery('(min-width: 768px)');
+
   // Computed values
   const activeEvents = useMemo(
     () => events.filter(event => event.status === 'active'),
     [events]
   );
+
+  // Enforce single event selection
+  React.useEffect(() => {
+    if (activeEvents.length > 0 && (!eventFilter || eventFilter === 'all' || !activeEvents.find(e => e.id === eventFilter))) {
+      setEventFilter(activeEvents[0].id);
+    }
+  }, [activeEvents, eventFilter]);
 
   // Filtered buyers - solo compradores de eventos activos
   const filteredBuyers = useMemo(() => {
@@ -34,47 +57,99 @@ export default function BuyersList() {
 
       if (!hasActiveEvent) return false;
 
-      const matchesSearch = 
+      const matchesSearch =
         buyer.firstName.toLowerCase().includes(searchTerm.toLowerCase()) ||
         buyer.lastName.toLowerCase().includes(searchTerm.toLowerCase()) ||
         buyer.phone.includes(searchTerm) ||
         buyer.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        // Buscar por nombre de vendedor
+        (() => {
+          const seller = sellers.find(s => s.id === buyer.sellerId);
+          return seller && (
+            seller.firstName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            seller.lastName.toLowerCase().includes(searchTerm.toLowerCase())
+          );
+        })() ||
         // Buscar por nombre de evento asignado
-        (buyer.assignedEvents.length > 0 && events.find(e => 
-          e.id === buyer.assignedEvents[0] && 
+        (buyer.assignedEvents.length > 0 && events.find(e =>
+          e.id === buyer.assignedEvents[0] &&
           e.status === 'active' &&
           e.name.toLowerCase().includes(searchTerm.toLowerCase())
         ));
       const matchesStatus = statusFilter === 'all' || buyer.status === statusFilter;
       const matchesEvent =
         eventFilter === 'all'
-          ? true
+          ? false // Should not happen with enforcement, but safe fallback
           : buyer.assignedEvents.some(eventId => {
-              const event = events.find(e => e.id === eventId);
-              return event?.status === 'active' && event.id === eventFilter;
-            });
-      
+            const event = events.find(e => e.id === eventId);
+            return event?.status === 'active' && event.id === eventFilter;
+          });
+
       return matchesSearch && matchesStatus && matchesEvent;
     });
-  }, [buyers, searchTerm, statusFilter, events, eventFilter]);
+  }, [buyers, searchTerm, statusFilter, events, eventFilter, sellers]);
+
+  // Close menus when clicking outside
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (mobileMenuOpen && !(event.target as Element).closest(`.${styles.mobileMenuContainer}`)) {
+        handleMobileMenuClose();
+      }
+      if (desktopMenuOpen && !(event.target as Element).closest(`.${styles.desktopMenuContainer}`)) {
+        setDesktopMenuOpen(null);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [mobileMenuOpen, desktopMenuOpen]);
 
   // Helper function: Check if buyer should show checkbox based on current filter
+  // Helper function: Check if buyer should show checkbox based on current filter
   const shouldShowCheckbox = (buyer: Buyer): boolean => {
+    // Show checkbox if buyer has any active event (raffle or food_sale)
     if (eventFilter !== 'all') {
-      // Si hay filtro específico, verificar si ESE evento es una rifa
       const filteredEvent = events.find(e => e.id === eventFilter);
-      return filteredEvent?.type === 'raffle' && filteredEvent?.status === 'active';
+      return !!filteredEvent && filteredEvent.status === 'active';
     } else {
-      // Sin filtro, mostrar checkbox si tiene alguna rifa activa
       return buyer.assignedEvents.some(eventId => {
         const event = events.find(e => e.id === eventId);
-        return event?.status === 'active' && event?.type === 'raffle';
+        return event?.status === 'active';
       });
     }
   };
 
+  // Determine selection type (raffle or food_sale)
+  const selectionType = useMemo(() => {
+    if (selectedBuyers.length === 0) return null;
+
+    // Check the first selected buyer's event type to determine the action
+    const firstBuyer = buyers.find(b => b.id === selectedBuyers[0]);
+    if (!firstBuyer || firstBuyer.assignedEvents.length === 0) return null;
+
+    // Find the relevant active event for this buyer
+    const activeEventId = firstBuyer.assignedEvents.find(eventId => {
+      const event = events.find(e => e.id === eventId);
+      return event?.status === 'active' && (eventFilter === 'all' || event.id === eventFilter);
+    });
+
+    const event = events.find(e => e.id === activeEventId);
+    return event?.type || null;
+  }, [selectedBuyers, buyers, events, eventFilter]);
+
+  // Check if all selected buyers are already delivered
+  const areAllSelectedDelivered = useMemo(() => {
+    if (selectedBuyers.length === 0) return false;
+    return selectedBuyers.every(id => {
+      const buyer = buyers.find(b => b.id === id);
+      return buyer?.isDelivered;
+    });
+  }, [selectedBuyers, buyers]);
+
   const handleToggleBuyerStatus = (buyerId: string) => {
-    setBuyers(prevBuyers => 
+    setBuyers(prevBuyers =>
       prevBuyers.map(buyer => {
         if (buyer.id === buyerId) {
           const newStatus = buyer.status === 'active' ? 'inactive' : 'active';
@@ -85,19 +160,50 @@ export default function BuyersList() {
     );
   };
 
+  // Desktop context menu handlers
+  const handleDesktopMenuToggle = (buyerId: string) => {
+    setDesktopMenuOpen(desktopMenuOpen === buyerId ? null : buyerId);
+  };
+
+  const handleDesktopToggleStatus = (buyerId: string) => {
+    handleToggleBuyerStatus(buyerId);
+    setDesktopMenuOpen(null);
+  };
+
+  // Mobile menu handlers
+  const handleMobileMenuToggle = (buyerId: string) => {
+    setMobileMenuOpen(mobileMenuOpen === buyerId ? null : buyerId);
+  };
+
+  const handleMobileMenuClose = () => {
+    setMobileMenuOpen(null);
+  };
+
+  const openFiltersSheet = () => setFiltersSheetOpen(true);
+  const closeFiltersSheet = () => setFiltersSheetOpen(false);
+
+  const handleMobileToggleStatus = (buyerId: string) => {
+    handleToggleBuyerStatus(buyerId);
+    handleMobileMenuClose();
+  };
+
+  const handleMobileAssignCancel = () => {
+    setSelectedBuyers([]);
+  };
+
   const handleSelectBuyer = (buyerId: string) => {
-    setSelectedBuyers(prev => 
-      prev.includes(buyerId) 
+    setSelectedBuyers(prev =>
+      prev.includes(buyerId)
         ? prev.filter(id => id !== buyerId)
         : [...prev, buyerId]
     );
   };
 
   const handleSelectAll = () => {
-    const raffleBuyers = filteredBuyers.filter(buyer => 
+    const raffleBuyers = filteredBuyers.filter(buyer =>
       buyer.status === 'active' && shouldShowCheckbox(buyer)
     );
-    
+
     if (selectedBuyers.length === raffleBuyers.length && raffleBuyers.length > 0) {
       setSelectedBuyers([]);
     } else {
@@ -111,72 +217,208 @@ export default function BuyersList() {
     alert(`Imprimiendo ${selectedBuyers.length} comprobantes`);
   };
 
+  const handleSetDeliveredStatus = (status: boolean) => {
+    setBuyers(prevBuyers =>
+      prevBuyers.map(buyer => {
+        if (selectedBuyers.includes(buyer.id)) {
+          return { ...buyer, isDelivered: status };
+        }
+        return buyer;
+      })
+    );
+
+    // Clear selection after action
+    setSelectedBuyers([]);
+  };
+
   return (
     <div className="pageContainer">
-      <div className={styles.header}>
-        <div className={styles.titleSection}>
-          <h1 className="pageTitle">Lista de Compradores</h1>
+      <div className={styles.stickyHeader}>
+        <div className={styles.header}>
+          <div className={styles.titleSection}>
+            <h1 className="pageTitle">Lista de Compradores</h1>
+          </div>
+        </div>
+
+        {/* Action Bar */}
+        <div className={styles.actionBar}>
+          <div className={styles.leftSection}>
+            <div className={styles.searchContainer}>
+              <svg className={styles.searchIcon} width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="11" cy="11" r="8" stroke="currentColor" strokeWidth="2" />
+                <path d="M21 21L16.65 16.65" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <input
+                type="text"
+                placeholder="Buscar compradores..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className={styles.searchInput}
+              />
+            </div>
+
+            {/* Desktop: dos filtros en línea */}
+            <div className={styles.filtersGroupDesktop}>
+              <div className={styles.statusFilter}>
+                <CustomDropdown
+                  options={STATUS_OPTIONS.map(opt => ({ value: opt.value, label: opt.label }))}
+                  value={statusFilter}
+                  onChange={(value) => setStatusFilter(value as StatusFilter)}
+                  placeholder="Filtrar por estado"
+                />
+              </div>
+              <div className={styles.eventFilter}>
+                <CustomDropdown
+                  options={[
+                    ...activeEvents.map(event => ({ value: event.id, label: event.name }))
+                  ]}
+                  value={eventFilter}
+                  onChange={(value) => setEventFilter(value as string)}
+                  placeholder="Filtrar por evento"
+                />
+              </div>
+            </div>
+
+            {/* Mobile: botón Filtros abre sheet */}
+            {!isDesktop && (
+              <button
+                type="button"
+                className={styles.filtersTriggerMobile}
+                onClick={openFiltersSheet}
+                aria-label="Abrir filtros"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path d="M4 6h16M4 12h16M4 18h7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <span>Filtros</span>
+              </button>
+            )}
+          </div>
+
+          {/* Dynamic Action Button based on selection type (Desktop) */}
+          {isDesktop && selectedBuyers.length > 0 && selectionType === 'raffle' && (
+            <button
+              onClick={handlePrintReceipts}
+              className="btn btn-primary"
+              title="Imprimir comprobantes"
+              style={{ gap: '8px' }}
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 9V2H18V9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M6 18H4C3.46957 18 2.96086 17.7893 2.58579 17.4142C2.21071 17.0391 2 16.5304 2 16V11C2 10.4696 2.21071 9.96086 2.58579 9.58579C2.96086 9.21071 3.46957 9 4 9H20C20.5304 9 21.0391 9.21071 21.4142 9.58579C21.7893 9.96086 22 10.4696 22 11V16C22 16.5304 21.7893 17.0391 21.4142 17.4142C21.0391 17.7893 20.5304 18 20 18H18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <rect x="6" y="14" width="12" height="8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <span>Imprimir comprobantes</span>
+            </button>
+          )}
+
+          {isDesktop && selectedBuyers.length > 0 && selectionType === 'food_sale' && (
+            <button
+              onClick={() => handleSetDeliveredStatus(!areAllSelectedDelivered)}
+              className="btn btn-primary"
+              title={areAllSelectedDelivered ? "Desmarcar como entregado" : "Marcar como entregado"}
+              style={{
+                gap: '8px',
+                backgroundColor: areAllSelectedDelivered ? 'var(--color-error)' : 'var(--color-success)',
+                borderColor: areAllSelectedDelivered ? 'var(--color-error)' : 'var(--color-success)'
+              }}
+            >
+              {areAllSelectedDelivered ? (
+                <>
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <span>Desmarcar</span>
+                </>
+              ) : (
+                <>
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <span>Entregado</span>
+                </>
+              )}
+            </button>
+          )}
         </div>
       </div>
 
-      {/* Action Bar */}
-      <div className={styles.actionBar}>
-        <div className={styles.leftSection}>
-          <div className={styles.searchContainer}>
-            <svg className={styles.searchIcon} width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="11" cy="11" r="8" stroke="currentColor" strokeWidth="2"/>
-              <path d="M21 21L16.65 16.65" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-            <input
-              type="text"
-              placeholder="Buscar por nombre, teléfono o evento"
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className={styles.searchInput}
-            />
-          </div>
-
-          {/* Desktop: dos filtros en línea */}
-          <div className={styles.filtersGroupDesktop}>
-            <div className={styles.statusFilter}>
-              <CustomDropdown
-                options={STATUS_OPTIONS.map(opt => ({ value: opt.value, label: opt.label }))}
-                value={statusFilter}
-                onChange={(value) => setStatusFilter(value as StatusFilter)}
-                placeholder="Filtrar por estado"
-              />
-            </div>
-            <div className={styles.eventFilter}>
-              <CustomDropdown
-                options={[
-                  { value: 'all', label: 'Todos los eventos activos' },
-                  ...activeEvents.map(event => ({ value: event.id, label: event.name }))
-                ]}
-                value={eventFilter}
-                onChange={(value) => setEventFilter(value as string)}
-                placeholder="Filtrar por evento"
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Print Button - Solo visible cuando hay seleccionados */}
-        {selectedBuyers.length > 0 && (
-          <button
-            onClick={handlePrintReceipts}
-            className="btn btn-primary"
-            title="Imprimir comprobantes"
-            style={{ gap: '8px' }}
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 9V2H18V9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <path d="M6 18H4C3.46957 18 2.96086 17.7893 2.58579 17.4142C2.21071 17.0391 2 16.5304 2 16V11C2 10.4696 2.21071 9.96086 2.58579 9.58579C2.96086 9.21071 3.46957 9 4 9H20C20.5304 9 21.0391 9.21071 21.4142 9.58579C21.7893 9.96086 22 10.4696 22 11V16C22 16.5304 21.7893 17.0391 21.4142 17.4142C21.0391 17.7893 20.5304 18 20 18H18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              <rect x="6" y="14" width="12" height="8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-            <span>Imprimir comprobantes</span>
+      {/* Mobile: sticky bottom bar para acciones (solo cuando hay selección) */}
+      {!isDesktop && selectedBuyers.length > 0 && (
+        <div className={styles.assignStickyBar}>
+          <button type="button" className={styles.assignStickyCancel} onClick={handleMobileAssignCancel}>
+            Cancelar
           </button>
-        )}
-      </div>
+          {selectionType === 'raffle' && (
+            <button
+              type="button"
+              className={styles.assignStickyPrimary}
+              onClick={handlePrintReceipts}
+            >
+              Imprimir {selectedBuyers.length} comprobante{selectedBuyers.length > 1 ? 's' : ''}
+            </button>
+          )}
+          {selectionType === 'food_sale' && (
+            <button
+              type="button"
+              className={styles.assignStickyPrimary}
+              onClick={() => handleSetDeliveredStatus(!areAllSelectedDelivered)}
+              style={{
+                backgroundColor: areAllSelectedDelivered ? 'var(--color-error)' : 'var(--color-success)',
+                color: 'white'
+              }}
+            >
+              {areAllSelectedDelivered ? 'Desmarcar' : 'Entregado'} ({selectedBuyers.length})
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Mobile: bottom sheet Filtros */}
+      {!isDesktop && filtersSheetOpen && (
+        <div className={styles.sheetOverlay} onClick={closeFiltersSheet} aria-hidden="true" />
+      )}
+      {!isDesktop && filtersSheetOpen && (
+        <div className={styles.sheetPanel} role="dialog" aria-label="Filtros" onClick={(e) => e.stopPropagation()}>
+          <div className={styles.sheetHandle} aria-hidden="true" />
+          <h2 className={styles.sheetTitle}>Filtros</h2>
+          <div className={styles.sheetFilters}>
+            <div className={styles.sheetFilterGroup}>
+              <span className={styles.sheetFilterLabel}>Estado</span>
+              <div className={styles.sheetFilterOptions}>
+                {STATUS_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={statusFilter === opt.value ? styles.sheetFilterOptionActive : styles.sheetFilterOption}
+                    onClick={() => setStatusFilter(opt.value as StatusFilter)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className={styles.sheetFilterGroup}>
+              <span className={styles.sheetFilterLabel}>Evento</span>
+              <div className={styles.sheetFilterOptions}>
+                {activeEvents.map((event) => (
+                  <button
+                    key={event.id}
+                    type="button"
+                    className={eventFilter === event.id ? styles.sheetFilterOptionActive : styles.sheetFilterOption}
+                    onClick={() => setEventFilter(event.id)}
+                  >
+                    {event.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+          <button type="button" className={styles.sheetApply} onClick={closeFiltersSheet}>
+            Aplicar
+          </button>
+        </div>
+      )}
 
       {/* Desktop Table View - Solo visible en desktop */}
       <div className={styles.tableContainer}>
@@ -206,15 +448,15 @@ export default function BuyersList() {
                 </div>
               </th>
               <th>Evento Asignado</th>
-              <th>Estado</th>
+              <th className={styles.actionsColumn}></th>
             </tr>
           </thead>
           <tbody>
             {filteredBuyers.map((buyer) => {
               const showCheckbox = shouldShowCheckbox(buyer);
               return (
-                <tr 
-                  key={buyer.id} 
+                <tr
+                  key={buyer.id}
                   className={`${styles.tableRow} ${buyer.status === 'inactive' ? styles.tableRowInactive : ''}`}
                 >
                   <td className={styles.checkboxColumn}>
@@ -228,9 +470,6 @@ export default function BuyersList() {
                           disabled={buyer.status === 'inactive'}
                           aria-label={`Seleccionar ${buyer.firstName} ${buyer.lastName}`}
                         />
-                        {buyer.status === 'inactive' && (
-                          <div className={styles.checkboxTooltip}>Comprador deshabilitado</div>
-                        )}
                       </div>
                     ) : (
                       <div className={styles.checkboxPlaceholder}></div>
@@ -240,53 +479,89 @@ export default function BuyersList() {
                     <div className={styles.buyerInfo}>
                       <div className={styles.buyerName}>
                         {buyer.firstName} {buyer.lastName}
+                        {buyer.isDelivered && (
+                          <span title="Entregado" style={{ marginLeft: '8px', display: 'inline-flex', alignItems: 'center', color: 'var(--color-success)' }}>
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                          </span>
+                        )}
                       </div>
                       <div className={styles.buyerPhone}>{buyer.phone}</div>
                     </div>
                   </td>
-                <td>
-                  <div className={styles.eventInfo}>
-                    {(() => {
-                      // Si hay filtro de evento, mostrar ese evento; sino mostrar el primer evento activo
-                      let displayEvent = null;
-                      
-                      if (eventFilter !== 'all') {
-                        // Mostrar el evento filtrado si el comprador lo tiene
-                        displayEvent = events.find(e => e.id === eventFilter && e.status === 'active');
-                      } else {
-                        // Mostrar el primer evento activo asignado
-                        const activeEventId = buyer.assignedEvents.find(eventId => {
-                          const event = events.find(e => e.id === eventId);
-                          return event?.status === 'active';
-                        });
-                        displayEvent = activeEventId ? events.find(e => e.id === activeEventId) : null;
-                      }
-                      
-                      return displayEvent ? (
-                        <div className={styles.eventName}>{displayEvent.name}</div>
-                      ) : (
-                        <div className={styles.noEvent}>Sin evento activo</div>
-                      );
-                    })()}
-                  </div>
-                </td>
                   <td>
-                    <div className={styles.switchWrapper}>
-                      <label 
-                        className={styles.switchContainer}
-                        title={buyer.status === 'active' ? 'Deshabilitar comprador' : 'Habilitar comprador'}
+                    <div className={styles.eventInfo}>
+                      {(() => {
+                        // Si hay filtro de evento, mostrar ese evento; sino mostrar el primer evento activo
+                        let displayEvent = null;
+
+                        if (eventFilter !== 'all') {
+                          // Mostrar el evento filtrado si el comprador lo tiene
+                          displayEvent = events.find(e => e.id === eventFilter && e.status === 'active');
+                        } else {
+                          // Mostrar el primer evento activo asignado
+                          const activeEventId = buyer.assignedEvents.find(eventId => {
+                            const event = events.find(e => e.id === eventId);
+                            return event?.status === 'active';
+                          });
+                          displayEvent = activeEventId ? events.find(e => e.id === activeEventId) : null;
+                        }
+
+                        return displayEvent ? (
+                          <div className={styles.eventName}>{displayEvent.name}</div>
+                        ) : (
+                          <div className={styles.noEvent}>Sin evento activo</div>
+                        );
+                      })()}
+                    </div>
+                  </td>
+                  <td className={styles.actionsColumn}>
+                    <div className={styles.desktopMenuContainer}>
+                      <button
+                        className={styles.desktopMenuButton}
+                        onClick={() => handleDesktopMenuToggle(buyer.id)}
+                        title="Más opciones"
+                        aria-label="Menú de opciones"
+                        aria-expanded={desktopMenuOpen === buyer.id}
+                        aria-haspopup="true"
                       >
-                        <input
-                          type="checkbox"
-                          checked={buyer.status === 'active'}
-                          onChange={() => handleToggleBuyerStatus(buyer.id)}
-                          className={styles.switchInput}
-                        />
-                        <span className={styles.switchSlider}></span>
-                      </label>
-                      <span className={`${styles.switchLabel} ${buyer.status === 'active' ? styles.switchLabelActive : styles.switchLabelInactive}`}>
-                        {buyer.status === 'active' ? 'HABILITADO' : 'DESHABILITADO'}
-                      </span>
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                          <circle cx="12" cy="6" r="1.5" fill="currentColor" />
+                          <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+                          <circle cx="12" cy="18" r="1.5" fill="currentColor" />
+                        </svg>
+                      </button>
+                      {desktopMenuOpen === buyer.id && (
+                        <div
+                          className={styles.desktopMenuDropdown}
+                          role="menu"
+                        >
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className={styles.desktopMenuItem}
+                            onClick={() => handleDesktopToggleStatus(buyer.id)}
+                          >
+                            {buyer.status === 'active' ? (
+                              <>
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                  <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                                Deshabilitar
+                              </>
+                            ) : (
+                              <>
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                  <path d="M9 12L11 14L15 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                  <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                                Habilitar
+                              </>
+                            )}
+                          </button>
+                        </div>
+                      )}
                     </div>
                   </td>
                 </tr>
@@ -295,14 +570,120 @@ export default function BuyersList() {
           </tbody>
         </table>
       </div>
-        
+
+      {/* Mobile List View — lista de filas, sin tabla; UX optimizada */}
+      {!isDesktop && (
+        <div
+          className={`${styles.mobileListContainer} ${selectedBuyers.length > 0 ? styles.hasStickyBar : ''}`}
+          role="list"
+        >
+          {filteredBuyers.map((buyer) => (
+            <article
+              key={buyer.id}
+              role="listitem"
+              className={`${styles.mobileListRow} ${buyer.status === 'inactive' ? styles.mobileRowInactive : ''} ${selectedBuyers.includes(buyer.id) ? styles.mobileRowSelected : ''}`}
+            >
+              <div className={styles.mobileRowCheckbox}>
+                {shouldShowCheckbox(buyer) ? (
+                  <input
+                    type="checkbox"
+                    id={`buyer-${buyer.id}`}
+                    checked={selectedBuyers.includes(buyer.id)}
+                    onChange={() => handleSelectBuyer(buyer.id)}
+                    disabled={buyer.status === 'inactive'}
+                    className={styles.mobileCheckbox}
+                    aria-label={`Seleccionar ${buyer.firstName} ${buyer.lastName}`}
+                  />
+                ) : (
+                  <div style={{ width: '24px' }}></div>
+                )}
+              </div>
+              <div className={styles.mobileRowMain}>
+                <div className={styles.mobileRowTop}>
+                  <h3 className={styles.mobileRowName}>
+                    {buyer.firstName} {buyer.lastName}
+                    {buyer.isDelivered && (
+                      <span title="Entregado" style={{ marginLeft: '8px', display: 'inline-flex', alignItems: 'center', color: 'var(--color-success)' }}>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </span>
+                    )}
+                  </h3>
+                  <div className={styles.mobileMenuContainer}>
+                    <button
+                      type="button"
+                      className={styles.mobileMenuButton}
+                      onClick={() => handleMobileMenuToggle(buyer.id)}
+                      title="Más opciones"
+                      aria-label="Menú de opciones"
+                      aria-expanded={mobileMenuOpen === buyer.id}
+                      aria-haspopup="true"
+                    >
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <circle cx="12" cy="6" r="1.5" fill="currentColor" />
+                        <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+                        <circle cx="12" cy="18" r="1.5" fill="currentColor" />
+                      </svg>
+                    </button>
+                    {mobileMenuOpen === buyer.id && (
+                      <div className={styles.mobileMenuDropdown} role="menu">
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className={styles.mobileMenuItem}
+                          onClick={() => handleMobileToggleStatus(buyer.id)}
+                        >
+                          {buyer.status === 'active' ? (
+                            <>
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                              Deshabilitar
+                            </>
+                          ) : (
+                            <>
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M9 12L11 14L15 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12 C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                              Habilitar
+                            </>
+                          )}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <p className={styles.mobileRowPhone}>{buyer.phone}</p>
+                <p className={styles.mobileRowEventLine}>
+                  {(() => {
+                    let displayEvent = null;
+                    if (eventFilter !== 'all') {
+                      displayEvent = events.find(e => e.id === eventFilter && e.status === 'active');
+                    } else {
+                      const activeEventId = buyer.assignedEvents.find(eventId => {
+                        const event = events.find(e => e.id === eventId);
+                        return event?.status === 'active';
+                      });
+                      displayEvent = activeEventId ? events.find(e => e.id === activeEventId) : null;
+                    }
+                    return displayEvent ? displayEvent.name : 'Sin evento activo';
+                  })()}
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
       {filteredBuyers.length === 0 && (
         <div className={styles.emptyState}>
           <svg width="64" height="64" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <circle cx="9" cy="7" r="4" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <path d="M23 21V19C23 18.1645 22.7155 17.3541 22.2094 16.6977C21.7033 16.0413 20.9999 15.5767 20.2 15.3778" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <path d="M16 3.37781C16.7999 3.57668 17.5033 4.04129 18.0094 4.6977C18.5155 5.35411 18.8 6.16449 18.8 7C18.8 7.83551 18.5155 8.64589 18.0094 9.3023C17.5033 9.95871 16.7999 10.4233 16 10.6222" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <circle cx="9" cy="7" r="4" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M23 21V19C23 18.1645 22.7155 17.3541 22.2094 16.6977C21.7033 16.0413 20.9999 15.5767 20.2 15.3778" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M16 3.37781C16.7999 3.57668 17.5033 4.04129 18.0094 4.6977C18.5155 5.35411 18.8 6.16449 18.8 7C18.8 7.83551 18.5155 8.64589 18.0094 9.3023C17.5033 9.95871 16.7999 10.4233 16 10.6222" stroke="#9CA3AF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
           <h3>No se encontraron compradores</h3>
           <p>Intenta ajustar los filtros de búsqueda</p>

--- a/src/app/event-detail/EventDetail.module.css
+++ b/src/app/event-detail/EventDetail.module.css
@@ -1,6 +1,7 @@
 /* Event Detail Container */
 .eventDetailContainer {
-  padding-bottom: var(--space-md) !important; /* Remove global padding-bottom since we handle it with salesList margin */
+  padding-bottom: var(--space-md) !important;
+  /* Remove global padding-bottom since we handle it with salesList margin */
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
@@ -16,7 +17,7 @@
 
 /* Navigation - Dark Mode Mobile First */
 .navigationContainer {
-  margin-bottom: var(--space-md);
+  margin-bottom: 32px;
   width: 100%;
   padding: 0;
 }
@@ -243,7 +244,8 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  margin-bottom: 90px; /* Space for fixed footer */
+  margin-bottom: 90px;
+  /* Space for fixed footer */
   width: 100%;
   padding: 0;
 }
@@ -384,10 +386,10 @@
     width: 100%;
     max-width: 1200px;
     margin: 0 auto;
-    padding: 40px;
+    padding: 0 40px 40px 40px;
     box-sizing: border-box;
   }
-  
+
   /* Asegurar que todos los elementos respeten el ancho del contenedor */
   .navigationContainer,
   .eventCard,
@@ -424,7 +426,7 @@
   .eventCard {
     padding: var(--space-lg);
   }
-  
+
   .eventTitle {
     font-size: var(--font-size-xl);
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,13 +6,13 @@
   --color-primary: #5AC8FA;
   --color-primary-hover: #7AD4FF;
   --color-primary-light: rgba(90, 200, 250, 0.1);
-  
+
   /* Colors - Semantic */
   --color-success: #34C759;
   --color-error: #FF3B30;
   --color-warning: #FF9500;
   --color-info: #5AC8FA;
-  
+
   /* Colors - Dark Mode Neutral */
   --color-white: #FFFFFF;
   --color-black: #000000;
@@ -24,7 +24,7 @@
   --color-text-tertiary: rgba(255, 255, 255, 0.5);
   --color-border: rgba(255, 255, 255, 0.2);
   --color-border-light: rgba(255, 255, 255, 0.1);
-  
+
   /* Legacy Gray Scale (for compatibility) */
   --color-gray-50: #1C1C1E;
   --color-gray-100: #2C2C2E;
@@ -36,7 +36,7 @@
   --color-gray-700: #C7C7CC;
   --color-gray-800: #D1D1D6;
   --color-gray-900: #E5E5EA;
-  
+
   /* Spacing */
   --space-xs: 8px;
   --space-sm: 12px;
@@ -45,7 +45,7 @@
   --space-xl: 24px;
   --space-2xl: 32px;
   --space-3xl: 48px;
-  
+
   /* Typography */
   --font-size-xs: 12px;
   --font-size-sm: 14px;
@@ -54,34 +54,34 @@
   --font-size-xl: 20px;
   --font-size-2xl: 24px;
   --font-size-3xl: 32px;
-  
+
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
-  
+
   /* Border Radius */
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
   --radius-xl: 16px;
   --radius-full: 9999px;
-  
+
   /* Shadows - Dark Mode */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.5);
   --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.6);
-  
+
   /* Transitions */
   --transition-fast: 0.15s ease;
   --transition-base: 0.2s ease;
   --transition-slow: 0.3s ease;
-  
+
   /* Layout - Mobile First */
   --header-height: 60px;
   --mobile-header-height: 60px;
-  
+
   /* Breakpoints (for reference) */
   --breakpoint-sm: 640px;
   --breakpoint-md: 768px;
@@ -119,7 +119,7 @@ body {
   background-color: var(--color-bg-primary);
   min-width: 0;
   max-width: 100vw;
-  overflow-x: hidden;
+  /* overflow-x: clip; - Removed */
 }
 
 /* Main Content - Mobile First */
@@ -131,7 +131,7 @@ body {
   background-color: var(--color-bg-primary);
   min-height: 100vh;
   padding-top: var(--mobile-header-height);
-  overflow-x: hidden;
+  /* overflow-x: hidden; - Removed */
 }
 
 /* Page Container - Mobile First */
@@ -140,8 +140,9 @@ body {
   max-width: 100%;
   padding: var(--space-md);
   min-height: calc(100vh - var(--mobile-header-height));
-  padding-bottom: 90px; /* Space for bottom button (16px container padding + 56px button + 16px container padding) */
-  overflow-x: hidden;
+  padding-bottom: 90px;
+  /* Space for bottom button (16px container padding + 56px button + 16px container padding) */
+  /* overflow-x: hidden; - Removed */
 }
 
 /* Content Container - width alignment helper */
@@ -187,14 +188,16 @@ body {
 @media (min-width: 768px) {
   .mainContent {
     padding-top: 0;
-    margin-left: 280px; /* mismo ancho que el sidebar fijo */
+    margin-left: 280px;
+    /* mismo ancho que el sidebar fijo */
   }
-  
+
   .pageContainer {
     max-width: 1200px;
     margin: 0 auto;
     padding: 40px;
-    padding-bottom: 110px; /* Space for bottom button on desktop */
+    padding-bottom: 110px;
+    /* Space for bottom button on desktop */
     box-sizing: border-box;
     width: 100%;
   }
@@ -208,11 +211,11 @@ body {
     max-width: 1200px;
     padding: 40px;
   }
-  
+
   .pageTitle {
     font-size: var(--font-size-3xl);
   }
-  
+
   .cardsContainer {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,7 +1,7 @@
 /* Header Section - Hidden on mobile, visible on desktop */
 .header {
   display: none;
-  margin-bottom: var(--space-2xl);
+  margin-bottom: 60px;
   justify-content: space-between;
   align-items: flex-start;
   gap: var(--space-lg);
@@ -27,7 +27,7 @@
 /* Filter Pills - Dark Mode Mobile First */
 .filtersContainer {
   margin-bottom: var(--space-md);
-  margin-top: 0;
+  margin-top: 40px;
   overflow-x: auto;
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
@@ -74,7 +74,8 @@
 }
 
 .pillBadge {
-  display: none; /* Hide badges in mobile design */
+  display: none;
+  /* Hide badges in mobile design */
 }
 
 .pill:hover {
@@ -173,6 +174,7 @@
     opacity: 0;
     transform: translateY(100%);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -303,8 +305,116 @@
   transform: scale(0.98);
 }
 
+.registerSaleSubmit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Mobile Wizard: Event Selection List */
+.registerSaleEventList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.registerSaleEventCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  width: 100%;
+  padding: var(--space-md);
+  background: var(--color-bg-tertiary);
+  border: 2px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  text-align: left;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.registerSaleEventCard:hover {
+  border-color: var(--color-border);
+}
+
+.registerSaleEventCardSelected {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.registerSaleEventCardContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.registerSaleEventCardTitle {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  line-height: 1.3;
+}
+
+.registerSaleEventCardStatus {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-success);
+}
+
+.registerSaleEventStatusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--color-success);
+}
+
+.registerSaleEventCard svg {
+  flex-shrink: 0;
+  color: var(--color-primary);
+}
+
+/* Mobile Wizard Navigation */
+.registerSaleWizardNav {
+  display: flex;
+  gap: var(--space-md);
+  margin-top: var(--space-sm);
+}
+
+.registerSaleBackButton {
+  flex: 1;
+  min-height: 48px;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-xl);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: background-color var(--transition-base);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.registerSaleBackButton:hover {
+  background: var(--color-border);
+}
+
+.registerSaleBackButton:active {
+  transform: scale(0.98);
+}
+
+.registerSaleWizardNav .registerSaleSubmit {
+  flex: 2;
+  margin-top: 0;
+}
+
 /* Ocultar sheet en desktop */
 @media (min-width: 768px) {
+
   .registerSaleSheetOverlay,
   .registerSaleSheetPanel {
     display: none !important;
@@ -423,6 +533,36 @@
   color: var(--color-text-tertiary);
 }
 
+/* Select dropdown specific styles */
+.registerSaleModalInput[type="select"],
+.registerSaleModalInput:is(select) {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23FFFFFF' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 40px;
+  cursor: pointer;
+}
+
+.registerSaleModalInput:is(select):focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-light);
+}
+
+.registerSaleModalInput:is(select) option {
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  padding: 12px;
+}
+
+.registerSaleModalInput:is(select) option:checked {
+  background-color: var(--color-primary);
+  color: var(--color-white);
+}
+
 .registerSaleModalInstruction {
   font-size: var(--font-size-sm);
   color: var(--color-text-tertiary);
@@ -487,6 +627,49 @@
   transform: scale(0.98);
 }
 
+.registerSaleModalSubmit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Desktop Wizard: Event Selection */
+.registerSaleDesktopEventList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.registerSaleDesktopEventCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  width: 100%;
+  padding: var(--space-lg);
+  background: var(--color-bg-tertiary);
+  border: 2px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  text-align: left;
+}
+
+.registerSaleDesktopEventCard:hover {
+  border-color: var(--color-border);
+  background: var(--color-bg-secondary);
+}
+
+.registerSaleDesktopEventCardSelected {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.registerSaleDesktopEventCard svg {
+  flex-shrink: 0;
+  color: var(--color-primary);
+}
+
 /* Mostrar modal solo en desktop */
 @media (min-width: 768px) {
   .registerSaleModalOverlay {
@@ -507,24 +690,25 @@
     max-width: 1200px;
     margin: 0 auto;
   }
-  
+
   .pageTitle {
     display: block;
     margin: 0;
   }
-  
+
   .filtersContainer {
     margin-bottom: var(--space-lg);
     max-width: 1200px;
     margin-left: auto;
     margin-right: auto;
   }
-  
+
   .pill {
     padding: 10px 20px;
   }
 
   .bottomButtonContainer {
-    display: none; /* Ocultar "Registrar venta" solo en desktop */
+    display: none;
+    /* Ocultar "Registrar venta" solo en desktop */
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,14 +37,20 @@ export default function Home() {
   const hasFilteredEvents = filteredEvents.length > 0;
 
   const [registerSaleSheetOpen, setRegisterSaleSheetOpen] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState<string>(''); // Event ID
+  const [mobileSheetStep, setMobileSheetStep] = useState<1 | 2>(1); // Mobile wizard step
+  const [desktopModalStep, setDesktopModalStep] = useState<1 | 2>(1); // Desktop wizard step
   const [saleQuantity, setSaleQuantity] = useState(1);
   const [saleBuyerName, setSaleBuyerName] = useState('');
   const [salePhone, setSalePhone] = useState('');
-  const [saleFormErrors, setSaleFormErrors] = useState<{ buyerName?: string; phone?: string }>({});
+  const [saleFormErrors, setSaleFormErrors] = useState<{ buyerName?: string; phone?: string; event?: string }>({});
 
   const openRegisterSaleSheet = () => setRegisterSaleSheetOpen(true);
   const closeRegisterSaleSheet = () => {
     setRegisterSaleSheetOpen(false);
+    setSelectedEvent('');
+    setMobileSheetStep(1);
+    setDesktopModalStep(1);
     setSaleQuantity(1);
     setSaleBuyerName('');
     setSalePhone('');
@@ -57,13 +63,21 @@ export default function Home() {
 
   const handleSubmitReceipt = (e: React.FormEvent) => {
     e.preventDefault();
-    const err: { buyerName?: string; phone?: string } = {};
+    const err: { buyerName?: string; phone?: string; event?: string } = {};
+
+    // Validate event selection
+    if (!selectedEvent) {
+      err.event = 'Debes seleccionar un evento';
+    }
+
     const nameErr = validateName(saleBuyerName);
     if (nameErr) err.buyerName = nameErr;
     const phoneErr = validatePhone(salePhone);
     if (phoneErr) err.phone = phoneErr;
     setSaleFormErrors(err);
     if (Object.keys(err).length > 0) return;
+
+    // TODO: Submit with selectedEvent, saleQuantity, saleBuyerName, salePhone
     closeRegisterSaleSheet();
   };
 
@@ -94,7 +108,7 @@ export default function Home() {
             </button>
           </div>
         </div>
-        
+
         {/* Filter Pills */}
         {hasEvents && (
           <div className={styles.filtersContainer}>
@@ -103,9 +117,8 @@ export default function Home() {
                 return (
                   <button
                     key={option.value}
-                    className={`${styles.pill} ${
-                      selectedFilter === option.value ? styles.pillActive : ''
-                    }`}
+                    className={`${styles.pill} ${selectedFilter === option.value ? styles.pillActive : ''
+                      }`}
                     onClick={() => setSelectedFilter(option.value as EventStatusFilter)}
                   >
                     <span className={styles.pillText}>{option.label}</span>
@@ -141,111 +154,102 @@ export default function Home() {
         </button>
       </div>
 
-      {/* Sheet: Registrar venta — SOLO MOBILE */}
+      {/* Sheet: Registrar venta — SOLO MOBILE - Multi-step Wizard */}
       {registerSaleSheetOpen && (
         <>
           <div className={styles.registerSaleSheetOverlay} onClick={closeRegisterSaleSheet} aria-hidden="true" />
           <div className={styles.registerSaleSheetPanel} role="dialog" aria-label="Registrar venta" onClick={(e) => e.stopPropagation()}>
             <div className={styles.registerSaleSheetHandle} aria-hidden="true" />
-            <div className={styles.registerSaleSheetHeader}>
-              <h2 className={styles.registerSaleSheetTitle}>
-                Rifa día del niño del Grupo Scout General Deheza
-              </h2>
-              <button
-                type="button"
-                className={styles.registerSaleSheetClose}
-                onClick={closeRegisterSaleSheet}
-                aria-label="Cerrar"
-              >
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                </svg>
-              </button>
-            </div>
-            <form onSubmit={handleSubmitReceipt} className={styles.registerSaleForm}>
-              <div className={styles.registerSaleField}>
-                <label className={styles.registerSaleLabel} htmlFor="sale-quantity-sheet">Cantidad de números</label>
-                <input
-                  id="sale-quantity-sheet"
-                  type="number"
-                  min={1}
-                  value={saleQuantity}
-                  onChange={(e) => {
-                    const v = parseInt(e.target.value, 10);
-                    setSaleQuantity(Number.isNaN(v) || v < 1 ? 1 : v);
-                  }}
-                  className={styles.registerSaleInput}
-                />
-              </div>
-              <div className={`${styles.registerSaleField} ${saleFormErrors.buyerName ? styles.registerSaleFieldError : ''}`}>
-                <label className={styles.registerSaleLabel} htmlFor="sale-buyer-sheet">Nombre del comprador</label>
-                <input
-                  id="sale-buyer-sheet"
-                  type="text"
-                  value={saleBuyerName}
-                  onChange={(e) => {
-                    setSaleBuyerName(e.target.value);
-                    if (saleFormErrors.buyerName) setSaleFormErrors((prev) => ({ ...prev, buyerName: undefined }));
-                  }}
-                  placeholder="Ej: María González"
-                  className={styles.registerSaleInput}
-                />
-                {saleFormErrors.buyerName && (
-                  <span className={styles.registerSaleError}>{saleFormErrors.buyerName}</span>
-                )}
-              </div>
-              <div className={`${styles.registerSaleField} ${saleFormErrors.phone ? styles.registerSaleFieldError : ''}`}>
-                <label className={styles.registerSaleLabel} htmlFor="sale-phone-sheet">Teléfono</label>
-                <input
-                  id="sale-phone-sheet"
-                  type="tel"
-                  value={salePhone}
-                  onChange={(e) => {
-                    setSalePhone(e.target.value);
-                    if (saleFormErrors.phone) setSaleFormErrors((prev) => ({ ...prev, phone: undefined }));
-                  }}
-                  placeholder="Ej: 3584129488"
-                  className={styles.registerSaleInput}
-                />
-                <span className={styles.registerSaleHelper}>Escribe el número sin 0 y sin 15</span>
-                {saleFormErrors.phone && (
-                  <span className={styles.registerSaleError}>{saleFormErrors.phone}</span>
-                )}
-              </div>
-              <button type="submit" className={styles.registerSaleSubmit}>
-                Enviar comprobante
-              </button>
-            </form>
-          </div>
-        </>
-      )}
 
-      {/* Modal: Registrar venta — SOLO DESKTOP (como edición de vendedor) */}
-      {registerSaleSheetOpen && (
-        <div className={styles.registerSaleModalOverlay} onClick={closeRegisterSaleSheet}>
-          <div className={styles.registerSaleModal} onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Registrar venta">
-            <div className={styles.registerSaleModalHeader}>
-              <h2 className={styles.registerSaleModalTitle}>
-                Rifa día del niño del Grupo Scout General Deheza
-              </h2>
-              <button
-                type="button"
-                className={styles.registerSaleModalClose}
-                onClick={closeRegisterSaleSheet}
-                aria-label="Cerrar"
-              >
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                </svg>
-              </button>
-            </div>
-            <div className={styles.registerSaleModalContent}>
-              <form onSubmit={handleSubmitReceipt} className={styles.registerSaleModalForm}>
-                <div className={styles.registerSaleFormCard}>
-                  <div className={styles.registerSaleFieldGroup}>
-                    <label className={styles.registerSaleModalLabel} htmlFor="sale-quantity-modal">Cantidad de números</label>
+            {/* Step 1: Event Selection */}
+            {mobileSheetStep === 1 && (
+              <>
+                <div className={styles.registerSaleSheetHeader}>
+                  <h2 className={styles.registerSaleSheetTitle}>
+                    Seleccionar evento
+                  </h2>
+                  <button
+                    type="button"
+                    className={styles.registerSaleSheetClose}
+                    onClick={closeRegisterSaleSheet}
+                    aria-label="Cerrar"
+                  >
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                </div>
+                <div className={styles.registerSaleEventList}>
+                  {MOCK_EVENTS.filter(e => e.status === 'active').map((event) => (
+                    <button
+                      key={event.id}
+                      type="button"
+                      className={`${styles.registerSaleEventCard} ${selectedEvent === event.id ? styles.registerSaleEventCardSelected : ''}`}
+                      onClick={() => {
+                        setSelectedEvent(event.id);
+                        if (saleFormErrors.event) setSaleFormErrors((prev) => ({ ...prev, event: undefined }));
+                      }}
+                    >
+                      <div className={styles.registerSaleEventCardContent}>
+                        <div className={styles.registerSaleEventCardTitle}>
+                          Rifa día del niño del Grupo Scout General Deheza
+                        </div>
+                        <div className={styles.registerSaleEventCardStatus}>
+                          <span className={styles.registerSaleEventStatusDot}></span>
+                          <span>ACTIVO</span>
+                        </div>
+                      </div>
+                      {selectedEvent === event.id && (
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      )}
+                    </button>
+                  ))}
+                </div>
+                {saleFormErrors.event && (
+                  <p className={styles.registerSaleError}>{saleFormErrors.event}</p>
+                )}
+                <button
+                  type="button"
+                  className={styles.registerSaleSubmit}
+                  onClick={() => {
+                    if (!selectedEvent) {
+                      setSaleFormErrors({ event: 'Debes seleccionar un evento' });
+                      return;
+                    }
+                    setMobileSheetStep(2);
+                  }}
+                  disabled={!selectedEvent}
+                >
+                  Continuar
+                </button>
+              </>
+            )}
+
+            {/* Step 2: Sale Details */}
+            {mobileSheetStep === 2 && (
+              <>
+                <div className={styles.registerSaleSheetHeader}>
+                  <h2 className={styles.registerSaleSheetTitle}>
+                    Rifa día del niño del Grupo Scout General Deheza
+                  </h2>
+                  <button
+                    type="button"
+                    className={styles.registerSaleSheetClose}
+                    onClick={closeRegisterSaleSheet}
+                    aria-label="Cerrar"
+                  >
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+                </div>
+                <form onSubmit={handleSubmitReceipt} className={styles.registerSaleForm}>
+                  <div className={styles.registerSaleField}>
+                    <label className={styles.registerSaleLabel} htmlFor="sale-quantity-sheet">Cantidad de números</label>
                     <input
-                      id="sale-quantity-modal"
+                      id="sale-quantity-sheet"
                       type="number"
                       min={1}
                       value={saleQuantity}
@@ -253,13 +257,13 @@ export default function Home() {
                         const v = parseInt(e.target.value, 10);
                         setSaleQuantity(Number.isNaN(v) || v < 1 ? 1 : v);
                       }}
-                      className={styles.registerSaleModalInput}
+                      className={styles.registerSaleInput}
                     />
                   </div>
-                  <div className={`${styles.registerSaleFieldGroup} ${saleFormErrors.buyerName ? styles.registerSaleModalFieldError : ''}`}>
-                    <label className={styles.registerSaleModalLabel} htmlFor="sale-buyer-modal">Nombre del comprador</label>
+                  <div className={`${styles.registerSaleField} ${saleFormErrors.buyerName ? styles.registerSaleFieldError : ''}`}>
+                    <label className={styles.registerSaleLabel} htmlFor="sale-buyer-sheet">Nombre del comprador</label>
                     <input
-                      id="sale-buyer-modal"
+                      id="sale-buyer-sheet"
                       type="text"
                       value={saleBuyerName}
                       onChange={(e) => {
@@ -267,16 +271,16 @@ export default function Home() {
                         if (saleFormErrors.buyerName) setSaleFormErrors((prev) => ({ ...prev, buyerName: undefined }));
                       }}
                       placeholder="Ej: María González"
-                      className={styles.registerSaleModalInput}
+                      className={styles.registerSaleInput}
                     />
                     {saleFormErrors.buyerName && (
-                      <p className={styles.registerSaleModalError}>{saleFormErrors.buyerName}</p>
+                      <span className={styles.registerSaleError}>{saleFormErrors.buyerName}</span>
                     )}
                   </div>
-                  <div className={`${styles.registerSaleFieldGroup} ${saleFormErrors.phone ? styles.registerSaleModalFieldError : ''}`}>
-                    <label className={styles.registerSaleModalLabel} htmlFor="sale-phone-modal">Teléfono</label>
+                  <div className={`${styles.registerSaleField} ${saleFormErrors.phone ? styles.registerSaleFieldError : ''}`}>
+                    <label className={styles.registerSaleLabel} htmlFor="sale-phone-sheet">Teléfono</label>
                     <input
-                      id="sale-phone-modal"
+                      id="sale-phone-sheet"
                       type="tel"
                       value={salePhone}
                       onChange={(e) => {
@@ -284,24 +288,197 @@ export default function Home() {
                         if (saleFormErrors.phone) setSaleFormErrors((prev) => ({ ...prev, phone: undefined }));
                       }}
                       placeholder="Ej: 3584129488"
-                      className={styles.registerSaleModalInput}
+                      className={styles.registerSaleInput}
                     />
-                    <p className={styles.registerSaleModalInstruction}>Escribe el número sin 0 y sin 15</p>
+                    <span className={styles.registerSaleHelper}>Escribe el número sin 0 y sin 15</span>
                     {saleFormErrors.phone && (
-                      <p className={styles.registerSaleModalError}>{saleFormErrors.phone}</p>
+                      <span className={styles.registerSaleError}>{saleFormErrors.phone}</span>
                     )}
                   </div>
-                </div>
-                <div className={styles.registerSaleModalActions}>
-                  <button type="button" className={styles.registerSaleModalCancel} onClick={closeRegisterSaleSheet}>
-                    Cancelar
+                  <div className={styles.registerSaleWizardNav}>
+                    <button
+                      type="button"
+                      className={styles.registerSaleBackButton}
+                      onClick={() => setMobileSheetStep(1)}
+                    >
+                      Atrás
+                    </button>
+                    <button type="submit" className={styles.registerSaleSubmit}>
+                      Enviar comprobante
+                    </button>
+                  </div>
+                </form>
+              </>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Modal: Registrar venta — SOLO DESKTOP - Wizard */}
+      {registerSaleSheetOpen && (
+        <div className={styles.registerSaleModalOverlay} onClick={closeRegisterSaleSheet}>
+          <div className={styles.registerSaleModal} onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Registrar venta">
+
+            {/* Step 1: Event Selection */}
+            {desktopModalStep === 1 && (
+              <>
+                <div className={styles.registerSaleModalHeader}>
+                  <h2 className={styles.registerSaleModalTitle}>
+                    Seleccionar evento
+                  </h2>
+                  <button
+                    type="button"
+                    className={styles.registerSaleModalClose}
+                    onClick={closeRegisterSaleSheet}
+                    aria-label="Cerrar"
+                  >
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
                   </button>
-                  <button type="submit" className={styles.registerSaleModalSubmit}>
-                    Enviar comprobante
+                </div>
+                <div className={styles.registerSaleModalContent}>
+                  <div className={styles.registerSaleDesktopEventList}>
+                    {MOCK_EVENTS.filter(e => e.status === 'active').map((event) => (
+                      <button
+                        key={event.id}
+                        type="button"
+                        className={`${styles.registerSaleDesktopEventCard} ${selectedEvent === event.id ? styles.registerSaleDesktopEventCardSelected : ''}`}
+                        onClick={() => {
+                          setSelectedEvent(event.id);
+                          if (saleFormErrors.event) setSaleFormErrors((prev) => ({ ...prev, event: undefined }));
+                        }}
+                      >
+                        <div className={styles.registerSaleEventCardContent}>
+                          <div className={styles.registerSaleEventCardTitle}>
+                            Rifa día del niño del Grupo Scout General Deheza
+                          </div>
+                          <div className={styles.registerSaleEventCardStatus}>
+                            <span className={styles.registerSaleEventStatusDot}></span>
+                            <span>ACTIVO</span>
+                          </div>
+                        </div>
+                        {selectedEvent === event.id && (
+                          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                  {saleFormErrors.event && (
+                    <p className={styles.registerSaleModalError}>{saleFormErrors.event}</p>
+                  )}
+                  <div className={styles.registerSaleModalActions}>
+                    <button type="button" className={styles.registerSaleModalCancel} onClick={closeRegisterSaleSheet}>
+                      Cancelar
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.registerSaleModalSubmit}
+                      onClick={() => {
+                        if (!selectedEvent) {
+                          setSaleFormErrors({ event: 'Debes seleccionar un evento' });
+                          return;
+                        }
+                        setDesktopModalStep(2);
+                      }}
+                      disabled={!selectedEvent}
+                    >
+                      Continuar
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {/* Step 2: Sale Form */}
+            {desktopModalStep === 2 && (
+              <>
+                <div className={styles.registerSaleModalHeader}>
+                  <h2 className={styles.registerSaleModalTitle}>
+                    Rifa día del niño del Grupo Scout General Deheza
+                  </h2>
+                  <button
+                    type="button"
+                    className={styles.registerSaleModalClose}
+                    onClick={closeRegisterSaleSheet}
+                    aria-label="Cerrar"
+                  >
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
                   </button>
                 </div>
-              </form>
-            </div>
+                <div className={styles.registerSaleModalContent}>
+                  <form onSubmit={handleSubmitReceipt} className={styles.registerSaleModalForm}>
+                    <div className={styles.registerSaleFormCard}>
+                      <div className={styles.registerSaleFieldGroup}>
+                        <label className={styles.registerSaleModalLabel} htmlFor="sale-quantity-modal">Cantidad de números</label>
+                        <input
+                          id="sale-quantity-modal"
+                          type="number"
+                          min={1}
+                          value={saleQuantity}
+                          onChange={(e) => {
+                            const v = parseInt(e.target.value, 10);
+                            setSaleQuantity(Number.isNaN(v) || v < 1 ? 1 : v);
+                          }}
+                          className={styles.registerSaleModalInput}
+                        />
+                      </div>
+                      <div className={`${styles.registerSaleFieldGroup} ${saleFormErrors.buyerName ? styles.registerSaleModalFieldError : ''}`}>
+                        <label className={styles.registerSaleModalLabel} htmlFor="sale-buyer-modal">Nombre del comprador</label>
+                        <input
+                          id="sale-buyer-modal"
+                          type="text"
+                          value={saleBuyerName}
+                          onChange={(e) => {
+                            setSaleBuyerName(e.target.value);
+                            if (saleFormErrors.buyerName) setSaleFormErrors((prev) => ({ ...prev, buyerName: undefined }));
+                          }}
+                          placeholder="Ej: María González"
+                          className={styles.registerSaleModalInput}
+                        />
+                        {saleFormErrors.buyerName && (
+                          <p className={styles.registerSaleModalError}>{saleFormErrors.buyerName}</p>
+                        )}
+                      </div>
+                      <div className={`${styles.registerSaleFieldGroup} ${saleFormErrors.phone ? styles.registerSaleModalFieldError : ''}`}>
+                        <label className={styles.registerSaleModalLabel} htmlFor="sale-phone-modal">Teléfono</label>
+                        <input
+                          id="sale-phone-modal"
+                          type="tel"
+                          value={salePhone}
+                          onChange={(e) => {
+                            setSalePhone(e.target.value);
+                            if (saleFormErrors.phone) setSaleFormErrors((prev) => ({ ...prev, phone: undefined }));
+                          }}
+                          placeholder="Ej: 3584129488"
+                          className={styles.registerSaleModalInput}
+                        />
+                        <p className={styles.registerSaleModalInstruction}>Escribe el número sin 0 y sin 15</p>
+                        {saleFormErrors.phone && (
+                          <p className={styles.registerSaleModalError}>{saleFormErrors.phone}</p>
+                        )}
+                      </div>
+                    </div>
+                    <div className={styles.registerSaleModalActions}>
+                      <button
+                        type="button"
+                        className={styles.registerSaleModalCancel}
+                        onClick={() => setDesktopModalStep(1)}
+                      >
+                        Atrás
+                      </button>
+                      <button type="submit" className={styles.registerSaleModalSubmit}>
+                        Enviar comprobante
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/src/app/sellers-list/SellersList.module.css
+++ b/src/app/sellers-list/SellersList.module.css
@@ -13,6 +13,17 @@
   flex: 1;
 }
 
+.stickyHeader {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: var(--color-bg-primary);
+  padding-top: var(--space-xl);
+  margin-top: calc(var(--space-xl) * -1);
+  padding-bottom: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
 .headerActions {
   display: flex;
   align-items: center;
@@ -31,10 +42,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--space-xl);
   gap: var(--space-lg);
   padding: 0;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .leftSection {
@@ -43,6 +54,7 @@
   align-items: center;
   flex: 1;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .rightSection {
@@ -76,8 +88,8 @@
 
 .searchContainer {
   position: relative;
-  flex: 1;
-  max-width: 400px;
+  flex: 1 1 300px;
+  min-width: 250px;
 }
 
 .searchIcon {
@@ -134,7 +146,10 @@
   gap: 20px;
   align-items: center;
   flex: 1;
+  flex-wrap: wrap;
 }
+
+
 
 /* Botón sin borde, solo icono (categoría ghost icon) */
 .filtersTriggerMobile {
@@ -268,6 +283,7 @@
     opacity: 0;
     transform: translateY(100%);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -518,21 +534,25 @@
 }
 
 .table th:nth-child(1) {
-  width: 60px !important; /* Checkbox column - Fixed width */
+  width: 60px !important;
+  /* Checkbox column - Fixed width */
   min-width: 60px !important;
   max-width: 60px !important;
 }
 
 .table th:nth-child(2) {
-  width: 40%; /* Vendedor name + phone */
+  width: 40%;
+  /* Vendedor name + phone */
 }
 
 .table th:nth-child(3) {
-  width: 45%; /* Evento Asignado */
+  width: 45%;
+  /* Evento Asignado */
 }
 
 .table th:nth-child(4) {
-  width: 15%; /* Acciones */
+  width: 15%;
+  /* Acciones */
 }
 
 .checkboxColumn {
@@ -612,10 +632,11 @@
 
 .tableRowInactive {
   color: var(--color-text-tertiary);
+  background-color: rgba(239, 68, 68, 0.08) !important;
 }
 
 .tableRowInactive:hover {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(239, 68, 68, 0.12) !important;
 }
 
 .tableRowInactive .sellerInfo,
@@ -653,7 +674,8 @@
   width: 60px !important;
   min-width: 60px !important;
   max-width: 60px !important;
-  padding: 12px 8px 12px 4px !important; /* Reduced left padding to bring checkboxes closer to table edge */
+  padding: 12px 8px 12px 4px !important;
+  /* Reduced left padding to bring checkboxes closer to table edge */
   text-align: center !important;
   vertical-align: middle !important;
 }
@@ -760,6 +782,7 @@
 
 .mobileRowInactive {
   color: var(--color-text-tertiary);
+  background-color: rgba(239, 68, 68, 0.08) !important;
 }
 
 .mobileRowInactive .mobileRowMain,
@@ -938,7 +961,7 @@
   background: #3C3C3E;
 }
 
-.desktopMenuItem + .desktopMenuItem {
+.desktopMenuItem+.desktopMenuItem {
   border-top: 1px solid var(--color-border-light);
 }
 
@@ -999,15 +1022,15 @@
   box-shadow: var(--shadow-sm);
 }
 
-.switchInput:checked + .switchSlider {
+.switchInput:checked+.switchSlider {
   background-color: var(--color-success);
 }
 
-.switchInput:not(:checked) + .switchSlider {
+.switchInput:not(:checked)+.switchSlider {
   background-color: var(--color-error);
 }
 
-.switchInput:checked + .switchSlider::before {
+.switchInput:checked+.switchSlider::before {
   transform: translateX(20px);
 }
 
@@ -1015,11 +1038,11 @@
   opacity: 0.9;
 }
 
-.switchInput:checked:focus + .switchSlider {
+.switchInput:checked:focus+.switchSlider {
   box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.2);
 }
 
-.switchInput:not(:checked):focus + .switchSlider {
+.switchInput:not(:checked):focus+.switchSlider {
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
 }
 
@@ -1378,6 +1401,7 @@
     bottom: -60px;
     opacity: 0;
   }
+
   to {
     bottom: 32px;
     opacity: 1;
@@ -1389,6 +1413,7 @@
     bottom: 32px;
     opacity: 1;
   }
+
   to {
     bottom: -60px;
     opacity: 0;
@@ -1405,7 +1430,8 @@
   }
 
   .headerActions {
-    display: none !important; /* Agregar vendedor: solo desktop */
+    display: none !important;
+    /* Agregar vendedor: solo desktop */
   }
 
   .subtitle {
@@ -1430,7 +1456,8 @@
   }
 
   .searchInput {
-    font-size: 16px; /* Prevent zoom on iOS */
+    font-size: 16px;
+    /* Prevent zoom on iOS */
     padding: 14px 12px 14px 44px;
     border-radius: 12px;
   }
@@ -1441,7 +1468,8 @@
   }
 
   .filterSelect {
-    font-size: 16px; /* Prevent zoom on iOS */
+    font-size: 16px;
+    /* Prevent zoom on iOS */
     padding: 14px 40px 14px 16px;
     border-radius: 12px;
     background-position: right 16px center;
@@ -1476,7 +1504,8 @@
   }
 
   .table th:nth-child(1) {
-    width: 60px !important; /* Checkbox column - Fixed width */
+    width: 60px !important;
+    /* Checkbox column - Fixed width */
     min-width: 60px !important;
     max-width: 60px !important;
   }
@@ -1509,7 +1538,8 @@
     width: 60px !important;
     min-width: 60px !important;
     max-width: 60px !important;
-    padding: 10px 6px 10px 3px !important; /* Reduced left padding to bring checkboxes closer to table edge */
+    padding: 10px 6px 10px 3px !important;
+    /* Reduced left padding to bring checkboxes closer to table edge */
     text-align: center !important;
     vertical-align: middle !important;
   }
@@ -1604,6 +1634,7 @@
       bottom: -60px;
       opacity: 0;
     }
+
     to {
       bottom: 24px;
       opacity: 1;
@@ -1615,6 +1646,7 @@
       bottom: 24px;
       opacity: 1;
     }
+
     to {
       bottom: -60px;
       opacity: 0;
@@ -1686,7 +1718,8 @@
   }
 
   .searchInput {
-    font-size: 16px; /* Prevent zoom on iOS */
+    font-size: 16px;
+    /* Prevent zoom on iOS */
     padding: var(--space-md) var(--space-sm) var(--space-md) 48px;
     border-radius: var(--radius-lg);
     border: 1px solid var(--color-border-light);
@@ -1708,7 +1741,8 @@
   }
 
   .mobileListContainer.hasStickyBar {
-    padding-bottom: 100px; /* Solo con selección: espacio para sticky Asignar */
+    padding-bottom: 100px;
+    /* Solo con selección: espacio para sticky Asignar */
   }
 
   /* Mobile list - ajustes */
@@ -1724,6 +1758,7 @@
 }
 
 @media (min-width: 641px) {
+
   .sheetOverlay,
   .sheetPanel {
     display: none !important;
@@ -1870,6 +1905,7 @@
       bottom: -60px;
       opacity: 0;
     }
+
     to {
       bottom: 20px;
       opacity: 1;
@@ -1881,6 +1917,7 @@
       bottom: 20px;
       opacity: 1;
     }
+
     to {
       bottom: -60px;
       opacity: 0;
@@ -1945,6 +1982,7 @@
     opacity: 0;
     transform: translateY(-10px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -2059,6 +2097,7 @@
       opacity: 0;
       transform: translateY(100%);
     }
+
     to {
       opacity: 1;
       transform: translateY(0);
@@ -2076,7 +2115,7 @@
     width: 100%;
     animation: slideUp 0.3s ease-out;
   }
-  
+
   .eventButtons {
     max-height: calc(70vh - 100px);
   }
@@ -2153,7 +2192,7 @@
   background: #3C3C3E;
 }
 
-.mobileMenuItem + .mobileMenuItem {
+.mobileMenuItem+.mobileMenuItem {
   border-top: 1px solid var(--color-border-light);
 }
 
@@ -2210,6 +2249,7 @@
     opacity: 0;
     transform: translateY(-6px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -2221,6 +2261,7 @@
     opacity: 0;
     transform: translateY(-8px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,6 +29,12 @@ const headerItems: HeaderItem[] = [
     label: 'Lista de vendedores',
     path: '/sellers-list',
     icon: 'people'
+  },
+  {
+    id: 'buyers-list',
+    label: 'Lista de compradores',
+    path: '/buyers-list',
+    icon: 'shopping'
   }
 ];
 
@@ -38,6 +44,7 @@ const getHeaderTitle = (pathname: string): string => {
   if (pathname === '/add-seller') return 'Agregar vendedor';
   if (pathname === '/create-event') return 'Crear evento';
   if (pathname === '/event-detail') return 'Detalle del evento';
+  if (pathname === '/buyers-list') return 'Lista de compradores';
   return 'Recauda';
 };
 
@@ -70,23 +77,30 @@ const Header: React.FC = () => {
       case 'home':
         return (
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 9L12 2L21 9V20C21 20.5304 20.7893 21.0391 20.4142 21.4142C20.0391 21.7893 19.5304 22 19 22H5C4.46957 22 3.96086 21.7893 3.58579 21.4142C3.21071 21.0391 3 20.5304 3 20V9Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <path d="M9 22V12H15V22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M3 9L12 2L21 9V20C21 20.5304 20.7893 21.0391 20.4142 21.4142C20.0391 21.7893 19.5304 22 19 22H5C4.46957 22 3.96086 21.7893 3.58579 21.4142C3.21071 21.0391 3 20.5304 3 20V9Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M9 22V12H15V22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         );
       case 'add':
         return (
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 5V19M5 12H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M12 5V19M5 12H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         );
       case 'people':
         return (
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <circle cx="9" cy="7" r="4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <path d="M23 21V19C23 18.1645 22.7155 17.3541 22.2094 16.6977C21.7033 16.0413 20.9999 15.5767 20.2 15.3778" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <path d="M16 3.37781C16.7999 3.57668 17.5033 4.04129 18.0094 4.6977C18.5155 5.35411 18.8 6.16449 18.8 7C18.8 7.83551 18.5155 8.64589 18.0094 9.3023C17.5033 9.95871 16.7999 10.4233 16 10.6222" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <circle cx="9" cy="7" r="4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M23 21V19C23 18.1645 22.7155 17.3541 22.2094 16.6977C21.7033 16.0413 20.9999 15.5767 20.2 15.3778" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M16 3.37781C16.7999 3.57668 17.5033 4.04129 18.0094 4.6977C18.5155 5.35411 18.8 6.16449 18.8 7C18.8 7.83551 18.5155 8.64589 18.0094 9.3023C17.5033 9.95871 16.7999 10.4233 16 10.6222" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        );
+      case 'shopping':
+        return (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M9 11L12 14L22 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M21 12V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         );
       default:
@@ -109,10 +123,10 @@ const Header: React.FC = () => {
             <span></span>
             <span></span>
           </button>
-          
+
           {/* Title - Centered (por sección) */}
           <h1 className={styles.title}>{headerTitle}</h1>
-          
+
           {/* Plus Icon: Agregar vendedor en Lista de vendedores, Crear evento en el resto */}
           <button
             className={styles.plusButton}
@@ -120,7 +134,7 @@ const Header: React.FC = () => {
             aria-label={pathname === '/sellers-list' ? 'Agregar vendedor' : 'Crear evento'}
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M12 5V19M5 12H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M12 5V19M5 12H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </button>
         </div>
@@ -137,20 +151,19 @@ const Header: React.FC = () => {
               aria-label="Cerrar menú"
             >
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             </button>
           </div>
-          
+
           <ul className={styles.menuList}>
             {headerItems
               .filter((item) => item.id !== 'create-event')
               .map((item) => (
                 <li key={item.id} className={styles.menuItem}>
                   <button
-                    className={`${styles.menuButton} ${
-                      pathname === item.path ? styles.menuButtonActive : ''
-                    }`}
+                    className={`${styles.menuButton} ${pathname === item.path ? styles.menuButtonActive : ''
+                      }`}
                     onClick={() => handleNavigation(item.path)}
                   >
                     <span className={styles.menuIcon}>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Custom hook for responsive design that detects if a media query matches
+ * @param query The media query to test (e.g., '(min-width: 768px)')
+ * @returns boolean indicating if the query matches
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    // Avoid running on server-side
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const media = window.matchMedia(query);
+    
+    // Set initial value
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+
+    // Define listener
+    const listener = () => {
+      setMatches(media.matches);
+    };
+
+    // Add listener
+    media.addEventListener('change', listener);
+    
+    // Clean up
+    return () => {
+      media.removeEventListener('change', listener);
+    };
+  }, [query, matches]);
+
+  return matches;
+}

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -135,6 +135,16 @@ const generateBuyers = (): Buyer[] => {
   const buyers: Buyer[] = [];
   let buyerId = 1;
 
+  const pickSellerForEvent = (eventId: string): { id: string; name: string } => {
+    const eligibleSellers = MOCK_SELLERS.filter(seller => seller.assignedEvents.includes(eventId));
+    const fallbackSellers = eligibleSellers.length > 0 ? eligibleSellers : MOCK_SELLERS;
+    const selectedSeller = fallbackSellers[Math.floor(Math.random() * fallbackSellers.length)];
+    return {
+      id: selectedSeller.id,
+      name: `${selectedSeller.firstName} ${selectedSeller.lastName}`
+    };
+  };
+
   // 100 compradores para RIFA (evento 1)
   for (let i = 0; i < 100; i++) {
     const firstName = firstNames[Math.floor(Math.random() * firstNames.length)];
@@ -142,10 +152,13 @@ const generateBuyers = (): Buyer[] => {
     const phone = `3584${String(100000 + buyerId).padStart(6, '0')}`;
     const isActive = Math.random() > 0.1; // 90% activos
     
+    const seller = pickSellerForEvent('1');
     buyers.push({
       id: String(buyerId),
       firstName,
       lastName,
+      sellerId: seller.id,
+      sellerName: seller.name,
       phone,
       email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}${buyerId}@email.com`,
       status: isActive ? 'active' : 'inactive',
@@ -164,10 +177,13 @@ const generateBuyers = (): Buyer[] => {
     const phone = `3584${String(100000 + buyerId).padStart(6, '0')}`;
     const isActive = Math.random() > 0.1; // 90% activos
     
+    const seller = pickSellerForEvent('2');
     buyers.push({
       id: String(buyerId),
       firstName,
       lastName,
+      sellerId: seller.id,
+      sellerName: seller.name,
       phone,
       email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}${buyerId}@email.com`,
       status: isActive ? 'active' : 'inactive',

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -19,6 +19,8 @@ export interface Buyer {
   id: string;
   firstName: string;
   lastName: string;
+  sellerId: string;
+  sellerName: string;
   phone: string;
   email: string;
   status: BuyerStatus;
@@ -26,6 +28,7 @@ export interface Buyer {
   assignedEvents: string[]; // Array of event IDs
   totalBought: number;
   lastActivity: string;
+  isDelivered?: boolean;
 }
 
 export interface Event {


### PR DESCRIPTION
- Add 2-step wizard for both mobile and desktop
- Step 1: Event selection with interactive cards (active events only)
- Step 2: Sale details form with navigation
- Desktop modal redesigned to match mobile wizard pattern
- Add validation for event selection before form submission
- Adjust spacing between header and filter pills (40px)
- Fix modal content padding to prevent buttons touching edges
- Add useMediaQuery hook for responsive behavior
- Update buyer and seller list disabled row styles