### PR TITLE
feat: flujo RegisterSale, rediseño event-detail y mejoras UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,13 @@
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "date-fns": "^4.1.0",
+        "lucide-react": "^0.575.0",
         "next": "15.5.9",
         "react": "^19.1.1",
         "react-datepicker": "^8.8.0",
         "react-dom": "^19.1.1",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/react-datepicker": "^6.2.0",
@@ -695,6 +697,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -808,6 +811,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.575.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
+      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -917,6 +929,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -941,6 +954,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -1072,6 +1086,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "date-fns": "^4.1.0",
+    "lucide-react": "^0.575.0",
     "next": "15.5.9",
     "react": "^19.1.1",
     "react-datepicker": "^8.8.0",
     "react-dom": "^19.1.1",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/react-datepicker": "^6.2.0",

--- a/src/app/event-detail/EventDetail.module.css
+++ b/src/app/event-detail/EventDetail.module.css
@@ -53,71 +53,73 @@
   transform: translateX(-2px);
 }
 
-/* Event Card - Dark Mode Mobile First */
-.eventCard {
-  background-color: var(--color-bg-secondary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-md);
-  margin-bottom: var(--space-md);
+/* Page Header — open layout, no card */
+.pageHeader {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
-  border: 1px solid var(--color-border-light);
-  width: 100%;
-  box-sizing: border-box;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-xl);
 }
 
-.eventCardHeader {
+/* Meta row: status + date */
+.metaRow {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--space-xs);
+  gap: var(--space-md);
 }
 
-.statusContainer {
-  display: flex;
+.statusBadge {
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
+  gap: 6px;
+  padding: 4px 10px;
+  background: rgba(52, 199, 89, 0.1);
+  border-radius: var(--radius-full);
 }
 
 .statusDot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background-color: var(--color-success);
   flex-shrink: 0;
 }
 
 .statusText {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
   color: var(--color-success);
+  letter-spacing: 0.5px;
 }
 
 .dateInfo {
   font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  text-align: right;
+  color: var(--color-text-tertiary);
 }
 
+/* H1 */
 .eventTitle {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
-  line-height: 1.4;
+  line-height: 1.3;
   margin: 0;
+  letter-spacing: -0.3px;
 }
 
-/* Progress Container */
-.progressContainer {
-  margin: var(--space-sm) 0;
+/* Progress bar */
+.progressSection {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
 }
 
-.progressBar {
+.progressTrack {
+  flex: 1;
   background-color: var(--color-bg-tertiary);
   border-radius: var(--radius-full);
-  height: 24px;
-  position: relative;
+  height: 8px;
   overflow: hidden;
 }
 
@@ -125,17 +127,52 @@
   background-color: var(--color-primary);
   border-radius: var(--radius-full);
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   transition: width var(--transition-slow);
 }
 
-.progressText {
-  color: var(--color-bg-primary);
-  font-size: var(--font-size-xs);
+.progressPct {
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
   white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 36px;
+  text-align: right;
+}
+
+/* Stats row */
+.statsRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.statValue {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  line-height: 1.1;
+}
+
+.statLabel {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.statDivider {
+  width: 1px;
+  height: 32px;
+  background: var(--color-border-light);
+  flex-shrink: 0;
 }
 
 .eventRow:hover .eventMenuDropdown {
@@ -211,6 +248,22 @@
 
 /* Mobile Responsiveness */
 @media (max-width: 768px) {
+
+  /* Override global H1 hide rule — needs higher specificity than .mainContent h1 (0,1,1) */
+  .pageHeader .eventTitle {
+    display: block !important;
+  }
+
+  /* Stack stats vertically on small screens */
+  .statsRow {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-md);
+  }
+
+  .statDivider {
+    display: none;
+  }
 
   /* Hide desktop inline buttons on mobile */
   .markAsPaidButton,
@@ -567,7 +620,7 @@
 
   /* Asegurar que todos los elementos respeten el ancho del contenedor */
   .navigationContainer,
-  .eventCard,
+  .pageHeader,
   .tableContainer {
     max-width: 100%;
     box-sizing: border-box;
@@ -603,12 +656,25 @@
     min-width: 200px;
   }
 
-  .eventCard {
-    padding: var(--space-lg);
+  .eventTitle {
+    font-size: var(--font-size-3xl);
+    letter-spacing: -0.5px;
   }
 
-  .eventTitle {
-    font-size: var(--font-size-xl);
+  .statsRow {
+    gap: var(--space-xl);
+  }
+
+  .statValue {
+    font-size: var(--font-size-2xl);
+  }
+
+  .statLabel {
+    font-size: var(--font-size-xs);
+  }
+
+  .statDivider {
+    height: 40px;
   }
 
   /* Hide original salesList on desktop - use tableView instead */

--- a/src/app/event-detail/page.tsx
+++ b/src/app/event-detail/page.tsx
@@ -137,35 +137,42 @@ export default function EventDetail() {
             </button>
           </div>
 
-          {/* Event Card */}
-          <div className={styles.eventCard}>
-            <div className={styles.eventCardHeader}>
-              <div className={styles.statusContainer}>
+          {/* Page Header */}
+          <div className={styles.pageHeader}>
+            <div className={styles.metaRow}>
+              <div className={styles.statusBadge}>
                 <span className={styles.statusDot}></span>
                 <span className={styles.statusText}>ACTIVO</span>
               </div>
-              <div className={styles.dateInfo}>
-                Finaliza el 20 de diciembre de 2025
-              </div>
+              <span className={styles.dateInfo}>Finaliza el 20 de diciembre de 2025</span>
             </div>
 
-            <h2 className={styles.eventTitle}>
+            <h1 className={styles.eventTitle}>
               Rifa día del niño del Grupo Scout General Deheza
-            </h2>
+            </h1>
 
-            {/* Progress Bar */}
-            <div className={styles.progressContainer}>
-              <div className={styles.progressBar}>
-                <div className={styles.progressFill} style={{ width: '80%' }}>
-                  <span className={styles.progressText}>80%</span>
-                </div>
+            <div className={styles.progressSection}>
+              <div className={styles.progressTrack}>
+                <div className={styles.progressFill} style={{ width: '80%' }} />
               </div>
+              <span className={styles.progressPct}>80%</span>
             </div>
 
-            {/* Bottom Details */}
-            <div className={styles.eventDetailsRow}>
-              <span className={styles.detailLeft}>Objetivo $300.000</span>
-              <span className={styles.detailRight}>300 números de $1.000</span>
+            <div className={styles.statsRow}>
+              <div className={styles.statItem}>
+                <span className={styles.statValue}>$240.000</span>
+                <span className={styles.statLabel}>Recaudado</span>
+              </div>
+              <div className={styles.statDivider} aria-hidden="true" />
+              <div className={styles.statItem}>
+                <span className={styles.statValue}>$300.000</span>
+                <span className={styles.statLabel}>Objetivo</span>
+              </div>
+              <div className={styles.statDivider} aria-hidden="true" />
+              <div className={styles.statItem}>
+                <span className={styles.statValue}>300</span>
+                <span className={styles.statLabel}>Números de $1.000</span>
+              </div>
             </div>
           </div>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,19 +16,19 @@
   /* Colors - Dark Mode Neutral */
   --color-white: #FFFFFF;
   --color-black: #000000;
-  --color-bg-primary: #000000;
-  --color-bg-secondary: #1C1C1E;
-  --color-bg-tertiary: #2C2C2E;
+  --color-bg-primary: #0A0A0F;
+  --color-bg-secondary: #141418;
+  --color-bg-tertiary: #1E1E25;
   --color-text-primary: #FFFFFF;
-  --color-text-secondary: rgba(255, 255, 255, 0.7);
-  --color-text-tertiary: rgba(255, 255, 255, 0.5);
-  --color-border: rgba(255, 255, 255, 0.2);
-  --color-border-light: rgba(255, 255, 255, 0.1);
+  --color-text-secondary: rgba(255, 255, 255, 0.65);
+  --color-text-tertiary: rgba(255, 255, 255, 0.4);
+  --color-border: rgba(255, 255, 255, 0.14);
+  --color-border-light: rgba(255, 255, 255, 0.07);
 
   /* Legacy Gray Scale (for compatibility) */
-  --color-gray-50: #1C1C1E;
-  --color-gray-100: #2C2C2E;
-  --color-gray-200: #3A3A3C;
+  --color-gray-50: #141418;
+  --color-gray-100: #1E1E25;
+  --color-gray-200: #2C2C35;
   --color-gray-300: #48484A;
   --color-gray-400: #636366;
   --color-gray-500: #8E8E93;
@@ -62,16 +62,16 @@
 
   /* Border Radius */
   --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-  --radius-xl: 16px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 18px;
   --radius-full: 9999px;
 
   /* Shadows - Dark Mode */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.5);
-  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.6);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 10px 24px rgba(0, 0, 0, 0.6);
+  --shadow-xl: 0 20px 40px rgba(0, 0, 0, 0.7);
 
   /* Transitions */
   --transition-fast: 0.15s ease;
@@ -104,12 +104,15 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   background-color: var(--color-bg-primary);
   color: var(--color-text-primary);
   line-height: 1.5;
   min-height: 100vh;
   overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'kern' 1;
 }
 
 /* App Layout - Mobile First */
@@ -163,7 +166,7 @@ body {
 .cardsContainer {
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: var(--space-lg);
   align-items: stretch;
   padding: 0;
   width: 100%;
@@ -213,13 +216,19 @@ body {
   }
 
   .cardsContainer {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-    gap: var(--space-lg);
+    display: block;
+    columns: 2;
+    column-gap: var(--space-xl);
     padding: 0;
     width: 100%;
     max-width: 1200px;
     margin: 0 auto;
+  }
+
+  .cardsContainer > * {
+    break-inside: avoid;
+    margin-bottom: var(--space-xl);
+    display: block;
   }
 }
 
@@ -236,6 +245,10 @@ body {
     margin-left: auto;
     margin-right: auto;
     /* Center the content in the available space */
+  }
+
+  .cardsContainer {
+    columns: 3;
   }
 }
 

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -54,18 +54,19 @@
   align-items: center;
   justify-content: center;
   gap: var(--space-xs);
-  padding: 8px 16px;
+  padding: 8px 18px;
   background: transparent;
-  border: 1px solid var(--color-border);
+  border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: var(--radius-full);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   cursor: pointer;
   transition: all var(--transition-base);
   white-space: nowrap;
   position: relative;
   flex-shrink: 0;
+  letter-spacing: 0.1px;
 }
 
 .pillText {
@@ -79,12 +80,12 @@
 }
 
 .pill:hover {
-  border-color: var(--color-text-primary);
-  opacity: 0.8;
+  border-color: rgba(255, 255, 255, 0.28);
+  color: var(--color-text-primary);
 }
 
 .pill:active {
-  transform: scale(0.98);
+  transform: scale(0.97);
 }
 
 .pillActive {
@@ -92,10 +93,11 @@
   border-color: var(--color-white);
   color: var(--color-bg-primary);
   font-weight: var(--font-weight-semibold);
+  letter-spacing: 0px;
 }
 
 .pillActive:hover {
-  opacity: 0.95;
+  opacity: 0.92;
 }
 
 /* Bottom Button Container */
@@ -106,29 +108,36 @@
   right: 0;
   width: 100%;
   max-width: 100vw;
-  background-color: var(--color-bg-primary);
-  border-top: 1px solid var(--color-border-light);
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.98) 70%, rgba(0, 0, 0, 0) 100%);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
   padding: var(--space-md);
+  padding-bottom: max(var(--space-md), env(safe-area-inset-bottom));
   z-index: 100;
   box-sizing: border-box;
 }
 
 .registerSaleButton {
-  background-color: #E5E5EA;
+  background-color: var(--color-white);
   color: var(--color-bg-primary);
   border: none;
   border-radius: var(--radius-xl);
   font-weight: var(--font-weight-semibold);
   padding: var(--space-md) var(--space-lg);
   font-size: var(--font-size-base);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
 }
 
 .registerSaleButton:hover {
-  background-color: #D1D1D6;
+  background-color: var(--color-gray-900);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
 .registerSaleButton:active {
   transform: scale(0.98);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
 }
 
 /* Mínimo 360px: evitar scroll horizontal */
@@ -286,19 +295,21 @@
   width: 100%;
   min-height: 48px;
   margin-top: var(--space-sm);
-  background: #E5E5EA;
+  background: var(--color-white);
   color: var(--color-bg-primary);
   border: none;
   border-radius: var(--radius-xl);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  transition: background-color var(--transition-base), transform var(--transition-base);
+  transition: all var(--transition-base);
   -webkit-tap-highlight-color: transparent;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .registerSaleSubmit:hover {
-  background: #D1D1D6;
+  background: var(--color-gray-900);
+  transform: translateY(-1px);
 }
 
 .registerSaleSubmit:active {
@@ -306,8 +317,9 @@
 }
 
 .registerSaleSubmit:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
+  transform: none;
 }
 
 /* Mobile Wizard: Event Selection List */
@@ -326,7 +338,7 @@
   width: 100%;
   padding: var(--space-md);
   background: var(--color-bg-tertiary);
-  border: 2px solid var(--color-border-light);
+  border: 1.5px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all var(--transition-base);
@@ -335,7 +347,8 @@
 }
 
 .registerSaleEventCard:hover {
-  border-color: var(--color-border);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .registerSaleEventCardSelected {
@@ -443,7 +456,8 @@
   max-width: 600px;
   max-height: 90vh;
   overflow-y: auto;
-  border: 1px solid var(--color-border-light);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
 }
 
 .registerSaleModalHeader {
@@ -608,19 +622,21 @@
 }
 
 .registerSaleModalSubmit {
-  background: #E5E5EA;
+  background: var(--color-white);
   color: var(--color-bg-primary);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   padding: 14px var(--space-xl);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   cursor: pointer;
   transition: all var(--transition-base);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .registerSaleModalSubmit:hover {
-  background: #D1D1D6;
+  background: var(--color-gray-900);
+  transform: translateY(-1px);
 }
 
 .registerSaleModalSubmit:active {
@@ -648,7 +664,7 @@
   width: 100%;
   padding: var(--space-lg);
   background: var(--color-bg-tertiary);
-  border: 2px solid var(--color-border-light);
+  border: 1.5px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all var(--transition-base);
@@ -656,8 +672,8 @@
 }
 
 .registerSaleDesktopEventCard:hover {
-  border-color: var(--color-border);
-  background: var(--color-bg-secondary);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .registerSaleDesktopEventCardSelected {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,117 +3,44 @@
 import React, { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { EventStatusFilter } from '@/types/models';
-import { EVENT_FILTER_OPTIONS } from '@/constants';
-import { validateName, validatePhone } from '@/utils/validation';
+import { EVENT_FILTER_OPTIONS, ROUTES } from '@/constants';
+import { MOCK_HOME_EVENTS } from '@/mocks/data';
 import CancelledEventCard from '@/components/CancelledEventCard';
 import ActiveEventCard from '@/components/ActiveEventCard';
 import FoodEventCard from '@/components/FoodEventCard';
 import CompletedEventCard from '@/components/CompletedEventCard';
 import CardEmptyState from '@/components/CardEmptyState';
 import EventsEmptyState from '@/components/EventsEmptyState';
+import RegisterSaleWizard from '@/components/wizard/RegisterSaleWizard';
 import styles from './page.module.css';
 
-// Mock events data - TODO: Replace with API
-const MOCK_EVENTS = [
-  {
-    id: '1',
-    status: 'active',
-    type: 'raffle',
-    name: 'Rifa día del niño del Grupo Scout General Deheza',
-    component: ActiveEventCard
-  },
-  {
-    id: '2',
-    status: 'active',
-    type: 'food_sale',
-    name: 'Venta de comida - Platos especiales',
-    component: FoodEventCard,
-    dishes: [
-      { name: 'Milanesa con papas', price: 2500, sold: 45, total: 100 },
-      { name: 'Empanadas (docena)', price: 3000, sold: 30, total: 80 },
-    ]
-  },
-  { id: '3', status: 'cancelled', type: 'raffle', name: 'Rifa cancelada', component: CancelledEventCard },
-  { id: '4', status: 'completed', type: 'raffle', name: 'Rifa completada', component: CompletedEventCard },
-  { id: '5', status: 'completed', type: 'raffle', name: 'Rifa completada 2', component: CompletedEventCard },
-];
+// Map event status to the correct card component
+const EVENT_CARD_MAP: Record<string, React.ComponentType<{ id?: string; title?: string; dishes?: { name: string; price: number }[]; collected?: number; goal?: number; soldUnits?: number; totalUnits?: number }>> = {
+  active_raffle: ActiveEventCard,
+  active_food_sale: FoodEventCard,
+  cancelled: CancelledEventCard,
+  completed: CompletedEventCard,
+};
+
+const getEventCardKey = (status: string, type: string): string => {
+  if (status === 'active') return `active_${type}`;
+  return status;
+};
 
 export default function Home() {
   const router = useRouter();
-  const [selectedFilter, setSelectedFilter] = useState<EventStatusFilter>('all');
+  const [selectedFilter, setSelectedFilter] = useState<EventStatusFilter>('active');
+  const [isSaleWizardOpen, setIsSaleWizardOpen] = useState(false);
 
-  // Filter events based on selected pill
   const filteredEvents = useMemo(() => {
-    if (selectedFilter === 'all') {
-      return MOCK_EVENTS;
-    }
-    return MOCK_EVENTS.filter(event => event.status === selectedFilter);
+    if (selectedFilter === 'all') return MOCK_HOME_EVENTS;
+    return MOCK_HOME_EVENTS.filter((event) => event.status === selectedFilter);
   }, [selectedFilter]);
 
-  const hasEvents = MOCK_EVENTS.length > 0;
+  const hasEvents = MOCK_HOME_EVENTS.length > 0;
   const hasFilteredEvents = filteredEvents.length > 0;
 
-  const [registerSaleSheetOpen, setRegisterSaleSheetOpen] = useState(false);
-  const [selectedEvent, setSelectedEvent] = useState<string>(''); // Event ID
-  const [mobileSheetStep, setMobileSheetStep] = useState<1 | 2>(1); // Mobile wizard step
-  const [desktopModalStep, setDesktopModalStep] = useState<1 | 2>(1); // Desktop wizard step
-  const [saleQuantity, setSaleQuantity] = useState(1);
-  const [saleBuyerName, setSaleBuyerName] = useState('');
-  const [salePhone, setSalePhone] = useState('');
-  const [saleFormErrors, setSaleFormErrors] = useState<{ buyerName?: string; phone?: string; event?: string; dishes?: string }>({});
-
-  // Food sale states
-  const [selectedDishes, setSelectedDishes] = useState<Record<string, number>>({}); // { dishName: quantity }
-
-  const openRegisterSaleSheet = () => setRegisterSaleSheetOpen(true);
-  const closeRegisterSaleSheet = () => {
-    setRegisterSaleSheetOpen(false);
-    setSelectedEvent('');
-    setMobileSheetStep(1);
-    setDesktopModalStep(1);
-    setSaleQuantity(1);
-    setSaleBuyerName('');
-    setSalePhone('');
-    setSaleFormErrors({});
-    setSelectedDishes({});
-  };
-
-  const handleRegisterSale = () => {
-    openRegisterSaleSheet();
-  };
-
-  const handleSubmitReceipt = (e: React.FormEvent) => {
-    e.preventDefault();
-    const err: { buyerName?: string; phone?: string; event?: string; dishes?: string } = {};
-
-    // Validate event selection
-    if (!selectedEvent) {
-      err.event = 'Debes seleccionar un evento';
-    }
-
-    // Validate dishes for food sale events
-    const currentEvent = MOCK_EVENTS.find(e => e.id === selectedEvent);
-    if (currentEvent?.type === 'food_sale') {
-      const totalDishes = Object.values(selectedDishes).reduce((sum, qty) => sum + qty, 0);
-      if (totalDishes === 0) {
-        err.dishes = 'Debes seleccionar al menos un plato';
-      }
-    }
-
-    const nameErr = validateName(saleBuyerName);
-    if (nameErr) err.buyerName = nameErr;
-    const phoneErr = validatePhone(salePhone);
-    if (phoneErr) err.phone = phoneErr;
-    setSaleFormErrors(err);
-    if (Object.keys(err).length > 0) return;
-
-    // TODO: Submit with selectedEvent, selectedDishes (for food), saleQuantity (for raffle), saleBuyerName, salePhone
-    closeRegisterSaleSheet();
-  };
-
-  const handleCreateEvent = () => {
-    router.push('/create-event');
-  };
+  const handleCreateEvent = () => router.push(ROUTES.CREATE_EVENT);
 
   return (
     <>
@@ -124,16 +51,10 @@ export default function Home() {
             <h1 className={`pageTitle ${styles.pageTitle}`}>Mis Eventos</h1>
           </div>
           <div className={styles.headerActions}>
-            <button
-              className="btn btn-secondary"
-              onClick={handleRegisterSale}
-            >
+            <button className="btn btn-secondary" onClick={() => setIsSaleWizardOpen(true)}>
               Registrar venta
             </button>
-            <button
-              className="btn btn-primary"
-              onClick={handleCreateEvent}
-            >
+            <button className="btn btn-primary" onClick={handleCreateEvent}>
               Crear evento
             </button>
           </div>
@@ -143,18 +64,15 @@ export default function Home() {
         {hasEvents && (
           <div className={styles.filtersContainer}>
             <div className={styles.pillsGroup}>
-              {EVENT_FILTER_OPTIONS.map((option) => {
-                return (
-                  <button
-                    key={option.value}
-                    className={`${styles.pill} ${selectedFilter === option.value ? styles.pillActive : ''
-                      }`}
-                    onClick={() => setSelectedFilter(option.value as EventStatusFilter)}
-                  >
-                    <span className={styles.pillText}>{option.label}</span>
-                  </button>
-                );
-              })}
+              {EVENT_FILTER_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  className={`${styles.pill} ${selectedFilter === option.value ? styles.pillActive : ''}`}
+                  onClick={() => setSelectedFilter(option.value as EventStatusFilter)}
+                >
+                  <span className={styles.pillText}>{option.label}</span>
+                </button>
+              ))}
             </div>
           </div>
         )}
@@ -167,448 +85,35 @@ export default function Home() {
         ) : (
           <div className="cardsContainer">
             {filteredEvents.map((event) => {
-              const EventComponent = event.component;
-              // Pass specific props for FoodEventCard
+              const cardKey = getEventCardKey(event.status, event.type);
+              const EventCard = EVENT_CARD_MAP[cardKey];
+              if (!EventCard) return null;
+
               if (event.type === 'food_sale' && event.dishes) {
-                return (
-                  <EventComponent
-                    key={event.id}
-                    id={event.id}
-                    title={event.name}
-                    dishes={event.dishes}
-                  />
-                );
+                return <EventCard key={event.id} id={event.id} title={event.name} dishes={event.dishes} />;
               }
-              return <EventComponent key={event.id} />;
+              return <EventCard key={event.id} collected={event.collected} goal={event.goal} soldUnits={event.soldUnits} totalUnits={event.totalUnits} />;
             })}
           </div>
         )}
       </div>
 
-      {/* Register Sale Button - Fixed at bottom */}
+      {/* Register Sale Button - Fixed at bottom (mobile only) */}
       <div className={styles.bottomButtonContainer}>
         <button
           className={`${styles.registerSaleButton} btn btn-full`}
-          onClick={handleRegisterSale}
+          onClick={() => setIsSaleWizardOpen(true)}
         >
           Registrar venta
         </button>
       </div>
 
-      {/* Sheet: Registrar venta — SOLO MOBILE - Multi-step Wizard */}
-      {registerSaleSheetOpen && (
-        <>
-          <div className={styles.registerSaleSheetOverlay} onClick={closeRegisterSaleSheet} aria-hidden="true" />
-          <div className={styles.registerSaleSheetPanel} role="dialog" aria-label="Registrar venta" onClick={(e) => e.stopPropagation()}>
-            <div className={styles.registerSaleSheetHandle} aria-hidden="true" />
-
-            {/* Step 1: Event Selection */}
-            {mobileSheetStep === 1 && (
-              <>
-                <div className={styles.registerSaleSheetHeader}>
-                  <h2 className={styles.registerSaleSheetTitle}>
-                    Seleccionar evento
-                  </h2>
-                  <button
-                    type="button"
-                    className={styles.registerSaleSheetClose}
-                    onClick={closeRegisterSaleSheet}
-                    aria-label="Cerrar"
-                  >
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </button>
-                </div>
-                <div className={styles.registerSaleEventList}>
-                  {MOCK_EVENTS.filter(e => e.status === 'active').map((event) => (
-                    <button
-                      key={event.id}
-                      type="button"
-                      className={`${styles.registerSaleEventCard} ${selectedEvent === event.id ? styles.registerSaleEventCardSelected : ''}`}
-                      onClick={() => {
-                        setSelectedEvent(event.id);
-                        if (saleFormErrors.event) setSaleFormErrors((prev) => ({ ...prev, event: undefined }));
-                      }}
-                    >
-                      <div className={styles.registerSaleEventCardContent}>
-                        <div className={styles.registerSaleEventCardStatus}>
-                          <span className={styles.registerSaleEventStatusDot}></span>
-                          <span>ACTIVO</span>
-                        </div>
-                        <div className={styles.registerSaleEventCardTitle}>
-                          {event.name || 'Rifa día del niño del Grupo Scout General Deheza'}
-                        </div>
-                      </div>
-                      {selectedEvent === event.id && (
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
-                      )}
-                    </button>
-                  ))}
-                </div>
-                {saleFormErrors.event && (
-                  <p className={styles.registerSaleError}>{saleFormErrors.event}</p>
-                )}
-                <button
-                  type="button"
-                  className={styles.registerSaleSubmit}
-                  onClick={() => {
-                    if (!selectedEvent) {
-                      setSaleFormErrors({ event: 'Debes seleccionar un evento' });
-                      return;
-                    }
-                    setMobileSheetStep(2);
-                  }}
-                  disabled={!selectedEvent}
-                >
-                  Continuar
-                </button>
-              </>
-            )}
-
-            {/* Step 2: Sale Details */}
-            {mobileSheetStep === 2 && (() => {
-              const currentEvent = MOCK_EVENTS.find(e => e.id === selectedEvent);
-              const isFoodSale = currentEvent?.type === 'food_sale';
-
-              return (
-                <>
-                  <div className={styles.registerSaleSheetHeader}>
-                    <h2 className={styles.registerSaleSheetTitle}>
-                      {currentEvent?.name || 'Rifa día del niño del Grupo Scout General Deheza'}
-                    </h2>
-                    <button
-                      type="button"
-                      className={styles.registerSaleSheetClose}
-                      onClick={closeRegisterSaleSheet}
-                      aria-label="Cerrar"
-                    >
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    </button>
-                  </div>
-                  <form onSubmit={handleSubmitReceipt} className={styles.registerSaleForm}>
-                    {isFoodSale && currentEvent?.dishes ? (
-                      // Food sale: Show dish selection
-                      <>
-                        <div className={styles.registerSaleField}>
-                          <label className={styles.registerSaleLabel}>Seleccionar platos</label>
-                          {currentEvent.dishes.map((dish, index) => (
-                            <div key={index} className={styles.dishSelector}>
-                              <div className={styles.dishSelectorHeader}>
-                                <span className={styles.dishSelectorName}>{dish.name}</span>
-                                <span className={styles.dishSelectorPrice}>${dish.price.toLocaleString()}</span>
-                              </div>
-                              <input
-                                type="number"
-                                min={0}
-                                value={selectedDishes[dish.name] || 0}
-                                onChange={(e) => {
-                                  const value = parseInt(e.target.value, 10) || 0;
-                                  setSelectedDishes(prev => ({
-                                    ...prev,
-                                    [dish.name]: value
-                                  }));
-                                  if (saleFormErrors.dishes) {
-                                    setSaleFormErrors(prev => ({ ...prev, dishes: undefined }));
-                                  }
-                                }}
-                                className={styles.registerSaleInput}
-                                placeholder="Cantidad"
-                              />
-                            </div>
-                          ))}
-                          {saleFormErrors.dishes && (
-                            <span className={styles.registerSaleError}>{saleFormErrors.dishes}</span>
-                          )}
-                        </div>
-                      </>
-                    ) : (
-                      // Raffle: Show quantity input
-                      <div className={styles.registerSaleField}>
-                        <label className={styles.registerSaleLabel} htmlFor="sale-quantity-sheet">Cantidad de números</label>
-                        <input
-                          id="sale-quantity-sheet"
-                          type="number"
-                          min={1}
-                          value={saleQuantity}
-                          onChange={(e) => {
-                            const v = parseInt(e.target.value, 10);
-                            setSaleQuantity(Number.isNaN(v) || v < 1 ? 1 : v);
-                          }}
-                          className={styles.registerSaleInput}
-                        />
-                      </div>
-                    )}
-                    <div className={`${styles.registerSaleField} ${saleFormErrors.buyerName ? styles.registerSaleFieldError : ''}`}>
-                      <label className={styles.registerSaleLabel} htmlFor="sale-buyer-sheet">Nombre del comprador</label>
-                      <input
-                        id="sale-buyer-sheet"
-                        type="text"
-                        value={saleBuyerName}
-                        onChange={(e) => {
-                          setSaleBuyerName(e.target.value);
-                          if (saleFormErrors.buyerName) setSaleFormErrors((prev) => ({ ...prev, buyerName: undefined }));
-                        }}
-                        placeholder="Ej: María González"
-                        className={styles.registerSaleInput}
-                      />
-                      {saleFormErrors.buyerName && (
-                        <span className={styles.registerSaleError}>{saleFormErrors.buyerName}</span>
-                      )}
-                    </div>
-                    <div className={`${styles.registerSaleField} ${saleFormErrors.phone ? styles.registerSaleFieldError : ''}`}>
-                      <label className={styles.registerSaleLabel} htmlFor="sale-phone-sheet">Teléfono</label>
-                      <input
-                        id="sale-phone-sheet"
-                        type="tel"
-                        value={salePhone}
-                        onChange={(e) => {
-                          setSalePhone(e.target.value);
-                          if (saleFormErrors.phone) setSaleFormErrors((prev) => ({ ...prev, phone: undefined }));
-                        }}
-                        placeholder="Ej: 3584129488"
-                        className={styles.registerSaleInput}
-                      />
-                      <span className={styles.registerSaleHelper}>Escribe el número sin 0 y sin 15</span>
-                      {saleFormErrors.phone && (
-                        <span className={styles.registerSaleError}>{saleFormErrors.phone}</span>
-                      )}
-                    </div>
-                    <div className={styles.registerSaleWizardNav}>
-                      <button
-                        type="button"
-                        className={styles.registerSaleBackButton}
-                        onClick={() => setMobileSheetStep(1)}
-                      >
-                        Atrás
-                      </button>
-                      <button type="submit" className={styles.registerSaleSubmit}>
-                        Enviar comprobante
-                      </button>
-                    </div>
-                  </form >
-                </>
-              );
-            })()}
-          </div>
-        </>
-      )}
-
-      {/* Modal: Registrar venta — SOLO DESKTOP - Wizard */}
-      {
-        registerSaleSheetOpen && (
-          <div className={styles.registerSaleModalOverlay} onClick={closeRegisterSaleSheet}>
-            <div className={styles.registerSaleModal} onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Registrar venta">
-
-              {/* Step 1: Event Selection */}
-              {desktopModalStep === 1 && (
-                <>
-                  <div className={styles.registerSaleModalHeader}>
-                    <h2 className={styles.registerSaleModalTitle}>
-                      Seleccionar evento
-                    </h2>
-                    <button
-                      type="button"
-                      className={styles.registerSaleModalClose}
-                      onClick={closeRegisterSaleSheet}
-                      aria-label="Cerrar"
-                    >
-                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    </button>
-                  </div>
-                  <div className={styles.registerSaleModalContent}>
-                    <div className={styles.registerSaleDesktopEventList}>
-                      {MOCK_EVENTS.filter(e => e.status === 'active').map((event) => (
-                        <button
-                          key={event.id}
-                          type="button"
-                          className={`${styles.registerSaleDesktopEventCard} ${selectedEvent === event.id ? styles.registerSaleDesktopEventCardSelected : ''}`}
-                          onClick={() => {
-                            setSelectedEvent(event.id);
-                            if (saleFormErrors.event) setSaleFormErrors((prev) => ({ ...prev, event: undefined }));
-                          }}
-                        >
-                          <div className={styles.registerSaleEventCardContent}>
-                            <div className={styles.registerSaleEventCardStatus}>
-                              <span className={styles.registerSaleEventStatusDot}></span>
-                              <span>ACTIVO</span>
-                            </div>
-                            <div className={styles.registerSaleEventCardTitle}>
-                              {event.name || 'Rifa día del niño del Grupo Scout General Deheza'}
-                            </div>
-                          </div>
-                          {selectedEvent === event.id && (
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                              <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                            </svg>
-                          )}
-                        </button>
-                      ))}
-                    </div>
-                    {saleFormErrors.event && (
-                      <p className={styles.registerSaleModalError}>{saleFormErrors.event}</p>
-                    )}
-                    <div className={styles.registerSaleModalActions}>
-                      <button type="button" className={styles.registerSaleModalCancel} onClick={closeRegisterSaleSheet}>
-                        Cancelar
-                      </button>
-                      <button
-                        type="button"
-                        className={styles.registerSaleModalSubmit}
-                        onClick={() => {
-                          if (!selectedEvent) {
-                            setSaleFormErrors({ event: 'Debes seleccionar un evento' });
-                            return;
-                          }
-                          setDesktopModalStep(2);
-                        }}
-                        disabled={!selectedEvent}
-                      >
-                        Continuar
-                      </button>
-                    </div>
-                  </div>
-                </>
-              )}
-
-              {/* Step 2: Sale Form */}
-              {desktopModalStep === 2 && (() => {
-                const currentEvent = MOCK_EVENTS.find(e => e.id === selectedEvent);
-                const isFoodSale = currentEvent?.type === 'food_sale';
-
-                return (
-                  <>
-                    <div className={styles.registerSaleModalHeader}>
-                      <h2 className={styles.registerSaleModalTitle}>
-                        {currentEvent?.name || 'Rifa día del niño del Grupo Scout General Deheza'}
-                      </h2>
-                      <button
-                        type="button"
-                        className={styles.registerSaleModalClose}
-                        onClick={closeRegisterSaleSheet}
-                        aria-label="Cerrar"
-                      >
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
-                      </button>
-                    </div>
-                    <div className={styles.registerSaleModalContent}>
-                      <form onSubmit={handleSubmitReceipt} className={styles.registerSaleModalForm}>
-                        <div className={styles.registerSaleFormCard}>
-                          {isFoodSale && currentEvent?.dishes ? (
-                            // Food sale: Show dish selection
-                            <div className={styles.registerSaleFieldGroup}>
-                              <label className={styles.registerSaleModalLabel}>Seleccionar platos</label>
-                              {currentEvent.dishes.map((dish, index) => (
-                                <div key={index} className={styles.dishSelector}>
-                                  <div className={styles.dishSelectorHeader}>
-                                    <span className={styles.dishSelectorName}>{dish.name}</span>
-                                    <span className={styles.dishSelectorPrice}>${dish.price.toLocaleString()}</span>
-                                  </div>
-                                  <input
-                                    type="number"
-                                    min={0}
-                                    value={selectedDishes[dish.name] || 0}
-                                    onChange={(e) => {
-                                      const value = parseInt(e.target.value, 10) || 0;
-                                      setSelectedDishes(prev => ({
-                                        ...prev,
-                                        [dish.name]: value
-                                      }));
-                                      if (saleFormErrors.dishes) {
-                                        setSaleFormErrors(prev => ({ ...prev, dishes: undefined }));
-                                      }
-                                    }}
-                                    className={styles.registerSaleModalInput}
-                                    placeholder="Cantidad"
-                                  />
-                                </div>
-                              ))}
-                              {saleFormErrors.dishes && (
-                                <p className={styles.registerSaleModalError}>{saleFormErrors.dishes}</p>
-                              )}
-                            </div>
-                          ) : (
-                            // Raffle: Show quantity input
-                            <div className={styles.registerSaleFieldGroup}>
-                              <label className={styles.registerSaleModalLabel} htmlFor="sale-quantity-modal">Cantidad de números</label>
-                              <input
-                                id="sale-quantity-modal"
-                                type="number"
-                                min={1}
-                                value={saleQuantity}
-                                onChange={(e) => {
-                                  const v = parseInt(e.target.value, 10);
-                                  setSaleQuantity(Number.isNaN(v) || v < 1 ? 1 : v);
-                                }}
-                                className={styles.registerSaleModalInput}
-                              />
-                            </div>
-                          )}
-                          <div className={`${styles.registerSaleFieldGroup} ${saleFormErrors.buyerName ? styles.registerSaleModalFieldError : ''}`}>
-                            <label className={styles.registerSaleModalLabel} htmlFor="sale-buyer-modal">Nombre del comprador</label>
-                            <input
-                              id="sale-buyer-modal"
-                              type="text"
-                              value={saleBuyerName}
-                              onChange={(e) => {
-                                setSaleBuyerName(e.target.value);
-                                if (saleFormErrors.buyerName) setSaleFormErrors((prev) => ({ ...prev, buyerName: undefined }));
-                              }}
-                              placeholder="Ej: María González"
-                              className={styles.registerSaleModalInput}
-                            />
-                            {saleFormErrors.buyerName && (
-                              <p className={styles.registerSaleModalError}>{saleFormErrors.buyerName}</p>
-                            )}
-                          </div>
-                          <div className={`${styles.registerSaleFieldGroup} ${saleFormErrors.phone ? styles.registerSaleModalFieldError : ''}`}>
-                            <label className={styles.registerSaleModalLabel} htmlFor="sale-phone-modal">Teléfono</label>
-                            <input
-                              id="sale-phone-modal"
-                              type="tel"
-                              value={salePhone}
-                              onChange={(e) => {
-                                setSalePhone(e.target.value);
-                                if (saleFormErrors.phone) setSaleFormErrors((prev) => ({ ...prev, phone: undefined }));
-                              }}
-                              placeholder="Ej: 3584129488"
-                              className={styles.registerSaleModalInput}
-                            />
-                            <p className={styles.registerSaleModalInstruction}>Escribe el número sin 0 y sin 15</p>
-                            {saleFormErrors.phone && (
-                              <p className={styles.registerSaleModalError}>{saleFormErrors.phone}</p>
-                            )}
-                          </div>
-                        </div>
-                        <div className={styles.registerSaleModalActions}>
-                          <button
-                            type="button"
-                            className={styles.registerSaleModalCancel}
-                            onClick={() => setDesktopModalStep(1)}
-                          >
-                            Atrás
-                          </button>
-                          <button type="submit" className={styles.registerSaleModalSubmit}>
-                            Enviar comprobante
-                          </button>
-                        </div>
-                      </form>
-                    </div>
-                  </>
-                );
-              })()}
-            </div>
-          </div>
-        )
-      }
+      {/* Register Sale Wizard — responsive (Sheet on mobile, Modal on desktop) */}
+      <RegisterSaleWizard
+        isOpen={isSaleWizardOpen}
+        onClose={() => setIsSaleWizardOpen(false)}
+        events={MOCK_HOME_EVENTS}
+      />
     </>
   );
 }

--- a/src/components/AccountForm.module.css
+++ b/src/components/AccountForm.module.css
@@ -1,8 +1,8 @@
 .formContainer {
-  background-color: white;
-  border-radius: 12px;
+  background-color: var(--color-bg-secondary);
+  border-radius: var(--radius-xl);
   padding: 24px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--color-border-light);
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
@@ -12,14 +12,14 @@
 .formTitle {
   font-size: 28px;
   font-weight: bold;
-  color: #000;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
   text-align: left;
 }
 
 .formSubtitle {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 32px;
   text-align: left;
 }
@@ -40,24 +40,25 @@
 .formLabel {
   font-size: 16px;
   font-weight: 600;
-  color: #000;
+  color: var(--color-text-primary);
   text-align: left;
 }
 
 .formInput {
   padding: 16px;
-  border: 2px solid #e0e0e0;
-  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   font-size: 16px;
-  background-color: #fff;
-  transition: border-color 0.3s ease;
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
   width: 100%;
 }
 
 .formInput:focus {
   outline: none;
-  border: 2px solid #007AFF;
-  box-shadow: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-light);
 }
 
 .formInput:focus-visible {
@@ -65,13 +66,13 @@
 }
 
 .formInput::placeholder {
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 16px;
 }
 
 .phoneInstruction {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-tertiary);
   margin-top: 4px;
 }
 
@@ -138,33 +139,33 @@
   content: '';
   flex: 1;
   height: 1px;
-  background-color: #e0e0e0;
+  background-color: var(--color-border-light);
 }
 
 .backToLoginButton {
-  background-color: transparent;
-  color: #007AFF;
-  border: 2px solid #007AFF;
+  background-color: var(--color-bg-primary);
+  color: var(--color-white);
+  border: 1px solid var(--color-white);
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 18px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all var(--transition-base);
   width: 100%;
 }
 
 .backToLoginButton:hover {
-  background-color: #007AFF;
-  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
 }
 
 .backToLoginButton:active {
   transform: translateY(1px);
+  background-color: rgba(255, 255, 255, 0.12);
 }
 
 .backToLoginButton:focus-visible {
-  outline: 2px solid #007AFF;
+  outline: 2px solid var(--color-white);
   outline-offset: 2px;
 }
 

--- a/src/components/ActiveEventCard.module.css
+++ b/src/components/ActiveEventCard.module.css
@@ -1,92 +1,104 @@
-/* Event Card - Dark Mode Mobile First */
+/* Active Event Card - Dark Mode Mobile First */
 .card {
   background-color: var(--color-bg-secondary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-md);
+  border-radius: var(--radius-xl);
+  padding: var(--space-lg);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
   cursor: pointer;
   transition: all var(--transition-base);
-  border: 1px solid var(--color-border-light);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
 .card:hover {
   background-color: var(--color-bg-tertiary);
-  border-color: var(--color-border);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+  transform: translateY(-1px);
 }
 
 .card:active {
   transform: scale(0.98);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
-/* Status Container */
+/* Status Badge - pill style */
 .statusContainer {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  margin-bottom: var(--space-xs);
+  gap: 6px;
+  padding: 4px 10px;
+  background: rgba(52, 199, 89, 0.12);
+  border-radius: var(--radius-full);
+  align-self: flex-start;
 }
 
 .statusDot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background-color: var(--color-success);
   flex-shrink: 0;
 }
 
 .statusText {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
   color: var(--color-success);
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
 }
 
 /* Date Info */
 .dateInfo {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  margin-bottom: var(--space-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
 }
 
 /* Event Title */
 .eventTitle {
   font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
-  line-height: 1.4;
+  line-height: 1.3;
   margin: 0;
-  margin-bottom: var(--space-sm);
 }
 
 /* Progress Container */
 .progressContainer {
-  margin: var(--space-sm) 0;
+  margin: var(--space-xs) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .progressBar {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-full);
-  height: 24px;
+  height: 6px;
   position: relative;
   overflow: hidden;
 }
 
 .progressFill {
-  background-color: var(--color-primary);
+  background: linear-gradient(90deg, var(--color-primary) 0%, #007AFF 100%);
   border-radius: var(--radius-full);
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   transition: width var(--transition-slow);
 }
 
+/* Bar is too thin to display text inside */
 .progressText {
-  color: var(--color-bg-primary);
+  display: none;
+}
+
+/* Unit Stats - below progress bar */
+.unitStats {
   font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
+  color: var(--color-text-tertiary);
+  text-align: right;
 }
 
 /* Details Row */
@@ -95,6 +107,8 @@
   justify-content: space-between;
   align-items: center;
   margin-top: var(--space-xs);
+  padding-top: var(--space-sm);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
   gap: var(--space-md);
 }
 
@@ -112,9 +126,9 @@
 /* Desktop */
 @media (min-width: 768px) {
   .card {
-    padding: var(--space-lg);
+    padding: var(--space-xl);
   }
-  
+
   .eventTitle {
     font-size: var(--font-size-xl);
   }

--- a/src/components/ActiveEventCard.tsx
+++ b/src/components/ActiveEventCard.tsx
@@ -4,9 +4,19 @@ import React from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './ActiveEventCard.module.css';
 
-const ActiveEventCard: React.FC = () => {
+interface Props {
+  collected?: number;
+  goal?: number;
+  soldUnits?: number;
+  totalUnits?: number;
+}
+
+const fmt = (n: number) => `$${new Intl.NumberFormat('es-AR').format(n)}`;
+
+const ActiveEventCard: React.FC<Props> = ({ collected = 0, goal = 0, soldUnits = 0, totalUnits = 0 }) => {
   const router = useRouter();
-  
+  const progress = goal > 0 ? Math.min((collected / goal) * 100, 100) : 0;
+
   const handleCardClick = () => {
     router.push('/event-detail');
   };
@@ -32,16 +42,17 @@ const ActiveEventCard: React.FC = () => {
       {/* Progress Bar */}
       <div className={styles.progressContainer}>
         <div className={styles.progressBar}>
-          <div className={styles.progressFill} style={{ width: '80%' }}>
-            <span className={styles.progressText}>80%</span>
+          <div className={styles.progressFill} style={{ width: `${progress}%` }}>
+            <span className={styles.progressText}>{Math.round(progress)}%</span>
           </div>
         </div>
+        <span className={styles.unitStats}>{soldUnits}/{totalUnits} vendidos</span>
       </div>
 
       {/* Bottom Details Row */}
       <div className={styles.detailsRow}>
-        <span className={styles.detailLeft}>Objetivo $300.000</span>
-        <span className={styles.detailRight}>300 números de $1.000</span>
+        <span className={styles.detailLeft}>Recaudado {fmt(collected)}</span>
+        <span className={styles.detailRight}>Objetivo {fmt(goal)}</span>
       </div>
     </div>
   );

--- a/src/components/CancelledEventCard.module.css
+++ b/src/components/CancelledEventCard.module.css
@@ -1,92 +1,104 @@
-/* Event Card - Dark Mode Mobile First */
+/* Cancelled Event Card - Dark Mode Mobile First */
 .card {
   background-color: var(--color-bg-secondary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-md);
+  border-radius: var(--radius-xl);
+  padding: var(--space-lg);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
   cursor: pointer;
   transition: all var(--transition-base);
-  border: 1px solid var(--color-border-light);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
 .card:hover {
   background-color: var(--color-bg-tertiary);
-  border-color: var(--color-border);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+  transform: translateY(-1px);
 }
 
 .card:active {
   transform: scale(0.98);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
-/* Status Container */
+/* Status Badge - pill style for cancelled */
 .statusContainer {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  margin-bottom: var(--space-xs);
+  gap: 6px;
+  padding: 4px 10px;
+  background: rgba(255, 59, 48, 0.10);
+  border-radius: var(--radius-full);
+  align-self: flex-start;
 }
 
 .statusDot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background-color: var(--color-error);
   flex-shrink: 0;
 }
 
 .statusText {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
   color: var(--color-error);
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
 }
 
 /* Date Info */
 .dateInfo {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  margin-bottom: var(--space-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
 }
 
 /* Event Title */
 .eventTitle {
   font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
-  line-height: 1.4;
+  line-height: 1.3;
   margin: 0;
-  margin-bottom: var(--space-sm);
 }
 
 /* Progress Container */
 .progressContainer {
-  margin: var(--space-sm) 0;
+  margin: var(--space-xs) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .progressBar {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-full);
-  height: 24px;
+  height: 6px;
   position: relative;
   overflow: hidden;
 }
 
 .progressFill {
-  background-color: var(--color-primary);
+  background: linear-gradient(90deg, var(--color-error) 0%, rgba(255, 59, 48, 0.6) 100%);
   border-radius: var(--radius-full);
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   transition: width var(--transition-slow);
 }
 
+/* Bar is too thin to display text inside */
 .progressText {
-  color: var(--color-bg-primary);
+  display: none;
+}
+
+/* Unit Stats - below progress bar */
+.unitStats {
   font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
+  color: var(--color-text-tertiary);
+  text-align: right;
 }
 
 /* Details Row */
@@ -95,6 +107,8 @@
   justify-content: space-between;
   align-items: center;
   margin-top: var(--space-xs);
+  padding-top: var(--space-sm);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
   gap: var(--space-md);
 }
 
@@ -112,9 +126,9 @@
 /* Desktop */
 @media (min-width: 768px) {
   .card {
-    padding: var(--space-lg);
+    padding: var(--space-xl);
   }
-  
+
   .eventTitle {
     font-size: var(--font-size-xl);
   }

--- a/src/components/CancelledEventCard.tsx
+++ b/src/components/CancelledEventCard.tsx
@@ -4,9 +4,19 @@ import React from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './CancelledEventCard.module.css';
 
-const CancelledEventCard: React.FC = () => {
+interface Props {
+  collected?: number;
+  goal?: number;
+  soldUnits?: number;
+  totalUnits?: number;
+}
+
+const fmt = (n: number) => `$${new Intl.NumberFormat('es-AR').format(n)}`;
+
+const CancelledEventCard: React.FC<Props> = ({ collected = 0, goal = 0, soldUnits = 0, totalUnits = 0 }) => {
   const router = useRouter();
-  
+  const progress = goal > 0 ? Math.min((collected / goal) * 100, 100) : 0;
+
   const handleCardClick = () => {
     router.push('/event-detail');
   };
@@ -21,7 +31,7 @@ const CancelledEventCard: React.FC = () => {
 
       {/* Date Info */}
       <div className={styles.dateInfo}>
-        Finaliza el 20 de diciembre de 2025
+        20 de diciembre de 2025
       </div>
 
       {/* Event Title */}
@@ -32,16 +42,17 @@ const CancelledEventCard: React.FC = () => {
       {/* Progress Bar */}
       <div className={styles.progressContainer}>
         <div className={styles.progressBar}>
-          <div className={styles.progressFill} style={{ width: '80%' }}>
-            <span className={styles.progressText}>80%</span>
+          <div className={styles.progressFill} style={{ width: `${progress}%` }}>
+            <span className={styles.progressText}>{Math.round(progress)}%</span>
           </div>
         </div>
+        <span className={styles.unitStats}>{soldUnits}/{totalUnits} vendidos</span>
       </div>
 
       {/* Bottom Details Row */}
       <div className={styles.detailsRow}>
-        <span className={styles.detailLeft}>Objetivo $300.000</span>
-        <span className={styles.detailRight}>300 números de $1.000</span>
+        <span className={styles.detailLeft}>Recaudado {fmt(collected)}</span>
+        <span className={styles.detailRight}>Objetivo {fmt(goal)}</span>
       </div>
     </div>
   );

--- a/src/components/CompletedEventCard.module.css
+++ b/src/components/CompletedEventCard.module.css
@@ -1,92 +1,104 @@
-/* Event Card - Dark Mode Mobile First */
+/* Completed Event Card - Dark Mode Mobile First */
 .card {
   background-color: var(--color-bg-secondary);
-  border-radius: var(--radius-lg);
-  padding: var(--space-md);
+  border-radius: var(--radius-xl);
+  padding: var(--space-lg);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
   cursor: pointer;
   transition: all var(--transition-base);
-  border: 1px solid var(--color-border-light);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
 .card:hover {
   background-color: var(--color-bg-tertiary);
-  border-color: var(--color-border);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+  transform: translateY(-1px);
 }
 
 .card:active {
   transform: scale(0.98);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
-/* Status Container */
+/* Status Badge - pill style for completed */
 .statusContainer {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-xs);
-  margin-bottom: var(--space-xs);
+  gap: 6px;
+  padding: 4px 10px;
+  background: rgba(142, 142, 147, 0.12);
+  border-radius: var(--radius-full);
+  align-self: flex-start;
 }
 
 .statusDot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background-color: var(--color-gray-500);
   flex-shrink: 0;
 }
 
 .statusText {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
   color: var(--color-gray-500);
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
 }
 
 /* Date Info */
 .dateInfo {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  margin-bottom: var(--space-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
 }
 
 /* Event Title */
 .eventTitle {
   font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
-  line-height: 1.4;
+  line-height: 1.3;
   margin: 0;
-  margin-bottom: var(--space-sm);
 }
 
 /* Progress Container */
 .progressContainer {
-  margin: var(--space-sm) 0;
+  margin: var(--space-xs) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .progressBar {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-full);
-  height: 24px;
+  height: 6px;
   position: relative;
   overflow: hidden;
 }
 
 .progressFill {
-  background-color: var(--color-primary);
+  background: linear-gradient(90deg, var(--color-gray-500) 0%, var(--color-gray-400) 100%);
   border-radius: var(--radius-full);
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   transition: width var(--transition-slow);
 }
 
+/* Bar is too thin to display text inside */
 .progressText {
-  color: var(--color-bg-primary);
+  display: none;
+}
+
+/* Unit Stats - below progress bar */
+.unitStats {
   font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
+  color: var(--color-text-tertiary);
+  text-align: right;
 }
 
 /* Details Row */
@@ -95,6 +107,8 @@
   justify-content: space-between;
   align-items: center;
   margin-top: var(--space-xs);
+  padding-top: var(--space-sm);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
   gap: var(--space-md);
 }
 
@@ -112,9 +126,9 @@
 /* Desktop */
 @media (min-width: 768px) {
   .card {
-    padding: var(--space-lg);
+    padding: var(--space-xl);
   }
-  
+
   .eventTitle {
     font-size: var(--font-size-xl);
   }

--- a/src/components/CompletedEventCard.tsx
+++ b/src/components/CompletedEventCard.tsx
@@ -4,9 +4,19 @@ import React from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './CompletedEventCard.module.css';
 
-const CompletedEventCard: React.FC = () => {
+interface Props {
+  collected?: number;
+  goal?: number;
+  soldUnits?: number;
+  totalUnits?: number;
+}
+
+const fmt = (n: number) => `$${new Intl.NumberFormat('es-AR').format(n)}`;
+
+const CompletedEventCard: React.FC<Props> = ({ collected = 0, goal = 0, soldUnits = 0, totalUnits = 0 }) => {
   const router = useRouter();
-  
+  const progress = goal > 0 ? Math.min((collected / goal) * 100, 100) : 100;
+
   const handleCardClick = () => {
     router.push('/event-detail');
   };
@@ -32,16 +42,17 @@ const CompletedEventCard: React.FC = () => {
       {/* Progress Bar */}
       <div className={styles.progressContainer}>
         <div className={styles.progressBar}>
-          <div className={styles.progressFill} style={{ width: '100%' }}>
-            <span className={styles.progressText}>100%</span>
+          <div className={styles.progressFill} style={{ width: `${progress}%` }}>
+            <span className={styles.progressText}>{Math.round(progress)}%</span>
           </div>
         </div>
+        <span className={styles.unitStats}>{soldUnits}/{totalUnits} vendidos</span>
       </div>
 
       {/* Bottom Details Row */}
       <div className={styles.detailsRow}>
-        <span className={styles.detailLeft}>Objetivo $300.000</span>
-        <span className={styles.detailRight}>300 números de $1.000</span>
+        <span className={styles.detailLeft}>Recaudado {fmt(collected)}</span>
+        <span className={styles.detailRight}>Objetivo {fmt(goal)}</span>
       </div>
     </div>
   );

--- a/src/components/EventsEmptyState.module.css
+++ b/src/components/EventsEmptyState.module.css
@@ -1,13 +1,14 @@
 .container {
-  background: white;
-  border-radius: 12px;
-  border: 1px solid #e0e0e0;
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border-light);
   padding: 20px;
-  flex: 0 0 calc(50% - 12px);
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 400px;
+  min-height: 300px;
+  width: 100%;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
 .emptyState {
@@ -17,15 +18,16 @@
 
 .flagIcon {
   font-size: 48px;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
   display: block;
+  opacity: 0.85;
 }
 
 .message {
-  font-size: 18px;
-  color: #333;
-  margin-bottom: 32px;
-  font-weight: 500;
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-xl);
+  font-weight: var(--font-weight-medium);
   line-height: 1.5;
 }
 
@@ -33,7 +35,7 @@
   background-color: var(--color-white);
   color: var(--color-bg-primary);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   padding: var(--space-sm) var(--space-xl);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
@@ -44,8 +46,9 @@
 .createButton:hover {
   background-color: var(--color-gray-900);
   color: var(--color-bg-primary);
+  transform: translateY(-1px);
 }
 
 .createButton:active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }

--- a/src/components/EventsEmptyState.tsx
+++ b/src/components/EventsEmptyState.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import { EventStatusFilter } from '@/types/models';
+import { ROUTES } from '@/constants';
 import styles from './EventsEmptyState.module.css';
 
 interface EventsEmptyStateProps {
@@ -34,10 +35,10 @@ const EMPTY_STATE_CONFIG = {
 
 const EventsEmptyState: React.FC<EventsEmptyStateProps> = ({ filterType = 'all' }) => {
   const router = useRouter();
-  const config = EMPTY_STATE_CONFIG[filterType];
-  
+  const config = EMPTY_STATE_CONFIG[filterType as keyof typeof EMPTY_STATE_CONFIG] ?? EMPTY_STATE_CONFIG.all;
+
   const handleCreateEvent = () => {
-    router.push('/create-event');
+    router.push(ROUTES.CREATE_EVENT);
   };
 
   return (

--- a/src/components/FoodEventCard.module.css
+++ b/src/components/FoodEventCard.module.css
@@ -1,89 +1,95 @@
 /* Food Event Card - Dark Mode Mobile First */
 .card {
     background-color: var(--color-bg-secondary);
-    border-radius: var(--radius-lg);
-    padding: var(--space-md);
+    border-radius: var(--radius-xl);
+    padding: var(--space-lg);
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
     cursor: pointer;
     transition: all var(--transition-base);
-    border: 1px solid var(--color-border-light);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
 .card:hover {
     background-color: var(--color-bg-tertiary);
-    border-color: var(--color-border);
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+    transform: translateY(-1px);
 }
 
 .card:active {
     transform: scale(0.98);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
-/* Status Container */
+/* Status Badge - pill style */
 .statusContainer {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: var(--space-xs);
-    margin-bottom: var(--space-xs);
+    gap: 6px;
+    padding: 4px 10px;
+    background: rgba(52, 199, 89, 0.12);
+    border-radius: var(--radius-full);
+    align-self: flex-start;
 }
 
 .statusDot {
-    width: 8px;
-    height: 8px;
+    width: 6px;
+    height: 6px;
     border-radius: 50%;
     background-color: var(--color-success);
     flex-shrink: 0;
 }
 
 .statusText {
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
+    font-size: 11px;
+    font-weight: var(--font-weight-semibold);
     color: var(--color-success);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
 }
 
 /* Date Info */
 .dateInfo {
-    font-size: var(--font-size-sm);
-    color: var(--color-text-secondary);
-    margin-bottom: var(--space-xs);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-tertiary);
 }
 
 /* Event Title */
 .eventTitle {
     font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-bold);
     color: var(--color-text-primary);
-    line-height: 1.4;
+    line-height: 1.3;
     margin: 0;
-    margin-bottom: var(--space-md);
 }
 
 /* Dishes Container */
 .dishesContainer {
     display: flex;
     flex-direction: column;
-    gap: var(--space-md);
-    margin: var(--space-sm) 0;
+    gap: var(--space-sm);
+    margin: var(--space-xs) 0;
 }
 
 .dishItem {
     display: flex;
     flex-direction: column;
-    gap: var(--space-xs);
+    gap: 6px;
 }
 
 .dishHeader {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 4px;
 }
 
 .dishName {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium);
-    color: var(--color-text-primary);
+    color: var(--color-text-secondary);
 }
 
 .dishPrice {
@@ -99,29 +105,23 @@
 }
 
 .progressBar {
-    background-color: var(--color-bg-tertiary);
+    background-color: rgba(255, 255, 255, 0.08);
     border-radius: var(--radius-full);
-    height: 20px;
+    height: 6px;
     position: relative;
     overflow: hidden;
 }
 
 .progressFill {
-    background-color: var(--color-primary);
+    background: linear-gradient(90deg, var(--color-primary) 0%, #007AFF 100%);
     border-radius: var(--radius-full);
     height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     transition: width var(--transition-slow);
-    min-width: 40px;
 }
 
+/* Bar is too thin to display text inside */
 .progressText {
-    color: var(--color-bg-primary);
-    font-size: 11px;
-    font-weight: var(--font-weight-semibold);
-    white-space: nowrap;
+    display: none;
 }
 
 .dishStats {
@@ -137,7 +137,7 @@
     align-items: center;
     margin-top: var(--space-xs);
     padding-top: var(--space-sm);
-    border-top: 1px solid var(--color-border-light);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
     gap: var(--space-md);
 }
 
@@ -155,7 +155,7 @@
 /* Desktop */
 @media (min-width: 768px) {
     .card {
-        padding: var(--space-lg);
+        padding: var(--space-xl);
     }
 
     .eventTitle {

--- a/src/components/FoodEventCard.tsx
+++ b/src/components/FoodEventCard.tsx
@@ -8,7 +8,7 @@ interface FoodEventCardProps {
     id?: string;
     title?: string;
     endDate?: string;
-    dishes?: Array<{ name: string; price: number; sold: number; total: number }>;
+    dishes?: Array<{ name: string; price: number; sold?: number; total?: number }>;
 }
 
 const FoodEventCard: React.FC<FoodEventCardProps> = ({
@@ -27,9 +27,10 @@ const FoodEventCard: React.FC<FoodEventCardProps> = ({
     };
 
     // Calculate totals
-    const totalRevenue = dishes.reduce((sum, dish) => sum + (dish.sold * dish.price), 0);
-    const totalGoal = dishes.reduce((sum, dish) => sum + (dish.total * dish.price), 0);
+    const totalRevenue = dishes.reduce((sum, dish) => sum + ((dish.sold ?? 0) * dish.price), 0);
+    const totalGoal = dishes.reduce((sum, dish) => sum + ((dish.total ?? 0) * dish.price), 0);
     const overallProgress = totalGoal > 0 ? Math.round((totalRevenue / totalGoal) * 100) : 0;
+
 
     return (
         <div className={styles.card} onClick={handleCardClick}>
@@ -48,7 +49,9 @@ const FoodEventCard: React.FC<FoodEventCardProps> = ({
             {/* Dishes List */}
             <div className={styles.dishesContainer}>
                 {dishes.map((dish, index) => {
-                    const dishProgress = dish.total > 0 ? Math.round((dish.sold / dish.total) * 100) : 0;
+                    const dishSold = dish.sold ?? 0;
+                    const dishTotal = dish.total ?? 0;
+                    const dishProgress = dishTotal > 0 ? Math.round((dishSold / dishTotal) * 100) : 0;
                     return (
                         <div key={index} className={styles.dishItem}>
                             <div className={styles.dishHeader}>
@@ -62,7 +65,7 @@ const FoodEventCard: React.FC<FoodEventCardProps> = ({
                                     </div>
                                 </div>
                                 <span className={styles.dishStats}>
-                                    {dish.sold}/{dish.total} vendidos
+                                    {dishSold}/{dishTotal} vendidos
                                 </span>
                             </div>
                         </div>

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -6,8 +6,10 @@
   right: 0;
   width: 100%;
   max-width: 100vw;
-  background-color: var(--color-bg-primary);
-  border-bottom: 1px solid var(--color-border-light);
+  background: rgba(0, 0, 0, 0.88);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   z-index: 1001;
   height: var(--header-height);
   overflow: hidden;
@@ -27,7 +29,7 @@
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
   margin: 0;
@@ -36,6 +38,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;
+  letter-spacing: -0.1px;
 }
 
 /* Hamburger Menu */
@@ -43,23 +46,24 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  width: 32px;
-  height: 32px;
-  background: transparent;
-  border: none;
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  padding: 6px;
+  padding: 9px;
   transition: all 0.3s ease;
   z-index: 2;
 }
 
 .hamburger:hover {
-  opacity: 0.7;
+  background: rgba(255, 255, 255, 0.10);
 }
 
 .hamburger span {
   display: block;
-  height: 2px;
+  height: 1.5px;
   width: 100%;
   background-color: var(--color-text-primary);
   border-radius: 2px;
@@ -67,7 +71,7 @@
 }
 
 .hamburgerOpen span:nth-child(1) {
-  transform: rotate(45deg) translate(6px, 6px);
+  transform: rotate(45deg) translate(5px, 5px);
 }
 
 .hamburgerOpen span:nth-child(2) {
@@ -76,7 +80,7 @@
 }
 
 .hamburgerOpen span:nth-child(3) {
-  transform: rotate(-45deg) translate(6px, -6px);
+  transform: rotate(-45deg) translate(5px, -5px);
 }
 
 /* Plus Button */
@@ -84,10 +88,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: transparent;
-  border: none;
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
   cursor: pointer;
   color: var(--color-text-primary);
   transition: all 0.2s ease;
@@ -95,7 +100,7 @@
 }
 
 .plusButton:hover {
-  opacity: 0.7;
+  background: rgba(255, 255, 255, 0.10);
 }
 
 .plusButton:active {
@@ -109,12 +114,12 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.75);
   z-index: 1000;
   opacity: 0;
   visibility: hidden;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(6px);
 }
 
 .menuOverlayOpen {
@@ -130,7 +135,7 @@
   width: min(280px, calc(100vw - 60px));
   max-width: 85vw;
   background: var(--color-bg-secondary);
-  border-left: 1px solid var(--color-border);
+  border-left: 1px solid rgba(255, 255, 255, 0.07);
   transform: translateX(100%);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
@@ -147,14 +152,15 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-lg);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .menuTitle {
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-primary);
   margin: 0;
+  letter-spacing: -0.2px;
 }
 
 .closeButton {
@@ -163,8 +169,8 @@
   justify-content: center;
   width: 32px;
   height: 32px;
-  background: transparent;
-  border: none;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-md);
   cursor: pointer;
   color: var(--color-text-secondary);
@@ -172,27 +178,28 @@
 }
 
 .closeButton:hover {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(255, 255, 255, 0.10);
   color: var(--color-text-primary);
 }
 
 .menuList {
   list-style: none;
   margin: 0;
-  padding: var(--space-sm) 0;
+  padding: var(--space-sm) var(--space-xs);
   flex: 1;
   overflow-y: auto;
 }
 
 .menuItem {
-  margin: 0;
+  margin: 0 0 2px 0;
 }
 
 .menuButton {
   width: 100%;
   background: none;
   border: none;
-  padding: var(--space-md) var(--space-lg);
+  border-radius: var(--radius-lg);
+  padding: 12px var(--space-md);
   display: flex;
   align-items: center;
   gap: var(--space-md);
@@ -206,18 +213,18 @@
 }
 
 .menuButton:hover {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(255, 255, 255, 0.06);
   color: var(--color-text-primary);
 }
 
 .menuButtonActive {
-  background-color: var(--color-bg-tertiary);
-  color: var(--color-text-primary);
-  border-left: 3px solid var(--color-primary);
+  background-color: rgba(90, 200, 250, 0.1);
+  color: var(--color-primary);
 }
 
 .menuButtonActive:hover {
-  background-color: var(--color-bg-tertiary);
+  background-color: rgba(90, 200, 250, 0.14);
+  color: var(--color-primary);
 }
 
 .menuIcon {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,51 +2,35 @@
 
 import React, { useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { Home, Plus, Users, ClipboardCheck, X, Menu } from 'lucide-react';
+import { ROUTES } from '@/constants';
 import styles from './Header.module.css';
 
 interface HeaderItem {
   id: string;
   label: string;
   path: string;
-  icon: string;
+  icon: React.ReactNode;
 }
 
 const headerItems: HeaderItem[] = [
-  {
-    id: 'home',
-    label: 'Mis Eventos',
-    path: '/',
-    icon: 'home'
-  },
-  {
-    id: 'create-event',
-    label: 'Crear evento',
-    path: '/create-event',
-    icon: 'add'
-  },
-  {
-    id: 'sellers-list',
-    label: 'Lista de vendedores',
-    path: '/sellers-list',
-    icon: 'people'
-  },
-  {
-    id: 'buyers-list',
-    label: 'Lista de compradores',
-    path: '/buyers-list',
-    icon: 'shopping'
-  }
+  { id: 'home', label: 'Mis Eventos', path: ROUTES.HOME, icon: <Home size={20} /> },
+  { id: 'create-event', label: 'Crear evento', path: ROUTES.CREATE_EVENT, icon: <Plus size={20} /> },
+  { id: 'sellers-list', label: 'Lista de vendedores', path: ROUTES.SELLERS_LIST, icon: <Users size={20} /> },
+  { id: 'buyers-list', label: 'Lista de compradores', path: ROUTES.BUYERS_LIST, icon: <ClipboardCheck size={20} /> },
 ];
 
-const getHeaderTitle = (pathname: string): string => {
-  const item = headerItems.find((i) => i.path === pathname);
-  if (item) return item.label;
-  if (pathname === '/add-seller') return 'Agregar vendedor';
-  if (pathname === '/create-event') return 'Crear evento';
-  if (pathname === '/event-detail') return 'Detalle del evento';
-  if (pathname === '/buyers-list') return 'Lista de compradores';
-  return 'Recauda';
+const ROUTE_TITLES: Record<string, string> = {
+  [ROUTES.HOME]: 'Mis Eventos',
+  [ROUTES.CREATE_EVENT]: 'Crear evento',
+  [ROUTES.SELLERS_LIST]: 'Lista de vendedores',
+  [ROUTES.BUYERS_LIST]: 'Lista de compradores',
+  [ROUTES.ADD_SELLER]: 'Agregar vendedor',
+  [ROUTES.EVENT_DETAIL]: 'Detalle del evento',
 };
+
+const getHeaderTitle = (pathname: string): string =>
+  ROUTE_TITLES[pathname] ?? 'Recauda';
 
 const Header: React.FC = () => {
   const router = useRouter();
@@ -59,53 +43,13 @@ const Header: React.FC = () => {
     setIsMenuOpen(false);
   };
 
-  const toggleMenu = () => {
-    setIsMenuOpen(!isMenuOpen);
-  };
+  const toggleMenu = () => setIsMenuOpen((prev) => !prev);
 
   const handlePlusAction = () => {
-    if (pathname === '/sellers-list') {
-      router.push('/add-seller');
-    } else {
-      router.push('/create-event');
-    }
+    const destination =
+      pathname === ROUTES.SELLERS_LIST ? ROUTES.ADD_SELLER : ROUTES.CREATE_EVENT;
+    router.push(destination);
     setIsMenuOpen(false);
-  };
-
-  const renderIcon = (iconName: string) => {
-    switch (iconName) {
-      case 'home':
-        return (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 9L12 2L21 9V20C21 20.5304 20.7893 21.0391 20.4142 21.4142C20.0391 21.7893 19.5304 22 19 22H5C4.46957 22 3.96086 21.7893 3.58579 21.4142C3.21071 21.0391 3 20.5304 3 20V9Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M9 22V12H15V22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        );
-      case 'add':
-        return (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 5V19M5 12H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        );
-      case 'people':
-        return (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            <circle cx="9" cy="7" r="4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M23 21V19C23 18.1645 22.7155 17.3541 22.2094 16.6977C21.7033 16.0413 20.9999 15.5767 20.2 15.3778" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M16 3.37781C16.7999 3.57668 17.5033 4.04129 18.0094 4.6977C18.5155 5.35411 18.8 6.16449 18.8 7C18.8 7.83551 18.5155 8.64589 18.0094 9.3023C17.5033 9.95871 16.7999 10.4233 16 10.6222" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        );
-      case 'shopping':
-        return (
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 11L12 14L22 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M21 12V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        );
-      default:
-        return null;
-    }
   };
 
   return (
@@ -131,18 +75,22 @@ const Header: React.FC = () => {
           <button
             className={styles.plusButton}
             onClick={handlePlusAction}
-            aria-label={pathname === '/sellers-list' ? 'Agregar vendedor' : 'Crear evento'}
+            aria-label={pathname === ROUTES.SELLERS_LIST ? 'Agregar vendedor' : 'Crear evento'}
           >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M12 5V19M5 12H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
+            <Plus size={24} />
           </button>
         </div>
       </header>
 
       {/* Mobile Menu Overlay */}
-      <div className={`${styles.menuOverlay} ${isMenuOpen ? styles.menuOverlayOpen : ''}`} onClick={toggleMenu}>
-        <nav className={`${styles.mobileMenu} ${isMenuOpen ? styles.mobileMenuOpen : ''}`} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={`${styles.menuOverlay} ${isMenuOpen ? styles.menuOverlayOpen : ''}`}
+        onClick={toggleMenu}
+      >
+        <nav
+          className={`${styles.mobileMenu} ${isMenuOpen ? styles.mobileMenuOpen : ''}`}
+          onClick={(e) => e.stopPropagation()}
+        >
           <div className={styles.menuHeader}>
             <h2 className={styles.menuTitle}>Recauda</h2>
             <button
@@ -150,9 +98,7 @@ const Header: React.FC = () => {
               onClick={toggleMenu}
               aria-label="Cerrar menú"
             >
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
+              <X size={24} />
             </button>
           </div>
 
@@ -166,9 +112,7 @@ const Header: React.FC = () => {
                       }`}
                     onClick={() => handleNavigation(item.path)}
                   >
-                    <span className={styles.menuIcon}>
-                      {renderIcon(item.icon)}
-                    </span>
+                    <span className={styles.menuIcon}>{item.icon}</span>
                     <span className={styles.menuLabel}>{item.label}</span>
                   </button>
                 </li>

--- a/src/components/LoginForm.module.css
+++ b/src/components/LoginForm.module.css
@@ -1,8 +1,8 @@
 .formContainer {
-  background-color: white;
-  border-radius: 12px;
+  background-color: var(--color-bg-secondary);
+  border-radius: var(--radius-xl);
   padding: 24px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--color-border-light);
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
@@ -12,14 +12,14 @@
 .formTitle {
   font-size: 28px;
   font-weight: bold;
-  color: #000;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
   text-align: left;
 }
 
 .formSubtitle {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 32px;
   text-align: left;
 }
@@ -40,24 +40,25 @@
 .formLabel {
   font-size: 16px;
   font-weight: 600;
-  color: #000;
+  color: var(--color-text-primary);
   text-align: left;
 }
 
 .formInput {
   padding: 16px;
-  border: 2px solid #e0e0e0;
-  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   font-size: 16px;
-  background-color: #fff;
-  transition: border-color 0.3s ease;
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
   width: 100%;
 }
 
 .formInput:focus {
   outline: none;
-  border: 2px solid #007AFF;
-  box-shadow: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-light);
 }
 
 .formInput:focus-visible {
@@ -65,13 +66,13 @@
 }
 
 .formInput::placeholder {
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 16px;
 }
 
 .phoneInstruction {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-tertiary);
   margin-top: 4px;
 }
 
@@ -131,40 +132,40 @@
   left: 0;
   right: 0;
   height: 1px;
-  background-color: #e0e0e0;
+  background-color: var(--color-border-light);
 }
 
 .divider span {
-  background-color: white;
+  background-color: var(--color-bg-secondary);
   padding: 0 16px;
-  color: #666;
+  color: var(--color-text-tertiary);
   font-size: 14px;
 }
 
 .createAccountButton {
-  background-color: transparent;
-  color: #007AFF;
-  border: 2px solid #007AFF;
+  background-color: var(--color-bg-primary);
+  color: var(--color-white);
+  border: 1px solid var(--color-white);
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 18px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all var(--transition-base);
   width: 100%;
 }
 
 .createAccountButton:hover {
-  background-color: #007AFF;
-  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
 }
 
 .createAccountButton:active {
   transform: translateY(1px);
+  background-color: rgba(255, 255, 255, 0.12);
 }
 
 .createAccountButton:focus-visible {
-  outline: 2px solid #007AFF;
+  outline: 2px solid var(--color-white);
   outline-offset: 2px;
 }
 

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -7,7 +7,7 @@
   /* Collapsed width - only icons */
   height: 100vh;
   background: var(--color-bg-secondary);
-  border-right: 1px solid var(--color-border-light);
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
   display: flex;
   flex-direction: column;
   z-index: 1000;
@@ -49,7 +49,7 @@
 /* Sidebar Header */
 .sidebarHeader {
   padding: 32px 20px;
-  border-bottom: 1px solid var(--color-border-light);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   background: var(--color-bg-secondary);
   min-height: 88px;
   /* Fixed height to prevent jumping */
@@ -114,7 +114,7 @@
   width: 100%;
   background: transparent;
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius-lg);
   padding: 10px 16px;
   display: flex;
   align-items: center;
@@ -122,9 +122,9 @@
   cursor: pointer;
   transition: all var(--transition-base);
   text-align: left;
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   font-size: 15px;
-  font-weight: 600;
+  font-weight: 500;
   position: relative;
   justify-content: flex-start;
 }
@@ -134,9 +134,9 @@
 }
 
 .sidebarButton:hover {
-  background: transparent;
+  background: rgba(255, 255, 255, 0.06);
   color: var(--color-text-primary);
-  opacity: 0.7;
+  opacity: 1;
 }
 
 .sidebarButton:hover::before {
@@ -144,9 +144,10 @@
 }
 
 .sidebarButtonActive {
-  background: transparent;
+  background: rgba(90, 200, 250, 0.10);
   color: var(--color-primary);
   border: none;
+  font-weight: 600;
 }
 
 .sidebarButtonActive::before {
@@ -154,9 +155,9 @@
 }
 
 .sidebarButtonActive:hover {
-  background: transparent;
+  background: rgba(90, 200, 250, 0.14);
   color: var(--color-primary);
-  opacity: 0.8;
+  opacity: 1;
 }
 
 .sidebarIcon {

--- a/src/components/wizard/ActionButtons.module.css
+++ b/src/components/wizard/ActionButtons.module.css
@@ -5,13 +5,14 @@
   right: 0;
   display: flex;
   justify-content: flex-end;
-  gap: 16px;
+  gap: 12px;
   padding: 20px 40px;
-  background: linear-gradient(to top, var(--color-bg-primary) 80%, rgba(0, 0, 0, 0.95) 90%, rgba(0, 0, 0, 0) 100%);
-  backdrop-filter: blur(8px);
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.98) 70%, rgba(0, 0, 0, 0.85) 88%, rgba(0, 0, 0, 0) 100%);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
   z-index: 100;
-  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.4);
-  border-top: 1px solid var(--color-border-light);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.5);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .backButton {
@@ -55,7 +56,7 @@
   background-color: var(--color-white);
   color: var(--color-bg-primary);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   padding: 14px 24px 14px 32px;
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
@@ -66,6 +67,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-xs);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .continueButton:hover {
@@ -135,35 +137,40 @@
 /* Responsive */
 @media (max-width: 768px) {
   .container {
-    padding: 16px 20px;
+    padding: 14px 20px;
+    justify-content: stretch;
+    padding-bottom: max(14px, env(safe-area-inset-bottom));
+  }
+
+  .backButton {
+    flex: 1;
+    padding: 13px 20px 13px 16px;
+    font-size: 15px;
     justify-content: center;
   }
-  
-  .backButton {
-    padding: 12px 24px 12px 20px;
-    font-size: 15px;
-  }
-  
+
   .continueButton {
-    padding: 12px 20px 12px 24px;
+    flex: 2;
+    padding: 13px 20px 13px 24px;
     font-size: 15px;
+    justify-content: center;
   }
 }
 
 @media (max-width: 480px) {
   .container {
     padding: 12px 16px;
-    gap: 12px;
+    gap: 10px;
+    padding-bottom: max(12px, env(safe-area-inset-bottom));
   }
-  
+
   .backButton {
-    padding: 12px 20px 12px 16px;
+    padding: 12px 16px;
     font-size: 14px;
   }
-  
+
   .continueButton {
-    padding: 12px 16px 12px 20px;
+    padding: 12px 16px;
     font-size: 14px;
   }
 }
-

--- a/src/components/wizard/AssignNumbersStep.module.css
+++ b/src/components/wizard/AssignNumbersStep.module.css
@@ -64,21 +64,31 @@
   align-items: center;
   gap: 0;
   width: 100%;
+  border-radius: var(--radius-md);
+  transition: box-shadow 0.2s ease;
+}
+
+.quantitySelector:focus-within {
+  box-shadow: 0 0 0 2px var(--color-primary);
 }
 
 .quantityButton {
-  width: 48px;
+  width: 52px;
   height: 48px;
   border: 1px solid var(--color-border);
   background: var(--color-bg-tertiary);
   color: var(--color-primary);
-  font-size: 20px;
-  font-weight: 500;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.15s ease, transform 0.1s ease;
   display: flex;
   align-items: center;
   justify-content: center;
+  user-select: none;
+  -webkit-user-select: none;
+  flex-shrink: 0;
 }
 
 .quantityButton:first-child {
@@ -92,12 +102,24 @@
 }
 
 .quantityButton:hover:not(:disabled) {
-  background: var(--color-primary-light);
+  background: var(--color-bg-secondary);
+}
+
+.quantityButton:active:not(:disabled) {
+  background: rgba(0, 122, 255, 0.15);
+  transform: scale(0.92);
+}
+
+.quantityButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  z-index: 1;
 }
 
 .quantityButton:disabled {
   color: var(--color-text-tertiary);
   cursor: not-allowed;
+  opacity: 0.4;
 }
 
 .quantityInput {
@@ -108,11 +130,12 @@
   border-right: none;
   background: var(--color-bg-tertiary);
   text-align: center;
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 18px;
+  font-weight: 600;
   color: var(--color-text-primary);
   outline: none;
   transition: background-color 0.2s ease;
+  min-width: 0;
 }
 
 .quantityInput:focus {

--- a/src/components/wizard/AssignNumbersStep.tsx
+++ b/src/components/wizard/AssignNumbersStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useImperativeHandle, forwardRef } from 'react';
+import React, { useState, useImperativeHandle, forwardRef, useRef } from 'react';
 import styles from './AssignNumbersStep.module.css';
 
 interface NumberAssignment {
@@ -32,30 +32,54 @@ const AssignNumbersStep = forwardRef<AssignNumbersStepRef, AssignNumbersStepProp
 
   const [errors, setErrors] = useState<Partial<NumberAssignment>>({});
 
+  // Refs for long-press continuous increment/decrement
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isLongPressRef = useRef(false);
+
+  // Functional update avoids stale closure inside setInterval
   const handleQuantityChange = (delta: number) => {
-    const newQuantity = Math.max(1, formData.quantity + delta);
-    setFormData(prev => ({ ...prev, quantity: newQuantity }));
+    setFormData(prev => ({ ...prev, quantity: Math.max(1, prev.quantity + delta) }));
+  };
+
+  // Start long-press: after 400ms hold, fire every 80ms
+  const startPress = (delta: number) => {
+    isLongPressRef.current = false;
+    pressTimerRef.current = setTimeout(() => {
+      isLongPressRef.current = true;
+      pressIntervalRef.current = setInterval(() => handleQuantityChange(delta), 80);
+    }, 400);
+  };
+
+  const stopPress = () => {
+    if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
+    if (pressIntervalRef.current) clearInterval(pressIntervalRef.current);
+  };
+
+  // Keyboard: ↑/+ increment, ↓/- decrement
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowUp' || e.key === '+') {
+      e.preventDefault();
+      handleQuantityChange(1);
+    } else if (e.key === 'ArrowDown' || e.key === '-') {
+      e.preventDefault();
+      handleQuantityChange(-1);
+    }
   };
 
   const handleQuantityInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    
-    // Permitir campo vacío temporalmente mientras el usuario escribe
     if (value === '') {
       setFormData(prev => ({ ...prev, quantity: 0 }));
       return;
     }
-    
     const numValue = parseInt(value, 10);
-    
-    // Solo actualizar si es un número válido y mayor a 0
     if (!isNaN(numValue) && numValue >= 1) {
       setFormData(prev => ({ ...prev, quantity: numValue }));
     }
   };
 
   const handleQuantityBlur = () => {
-    // Si el campo está vacío o es 0, establecer el mínimo valor (1)
     if (formData.quantity <= 0) {
       setFormData(prev => ({ ...prev, quantity: 1 }));
     }
@@ -64,7 +88,6 @@ const AssignNumbersStep = forwardRef<AssignNumbersStepRef, AssignNumbersStepProp
   const handleInputChange = (field: keyof NumberAssignment) => (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setFormData(prev => ({ ...prev, [field]: value }));
-    
     if (errors[field]) {
       setErrors(prev => ({ ...prev, [field]: undefined }));
     }
@@ -100,30 +123,44 @@ const AssignNumbersStep = forwardRef<AssignNumbersStepRef, AssignNumbersStepProp
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Asignar números</h1>
-      
+
       <div className={styles.formCard}>
         <div className={styles.fieldGroup}>
           <label className={styles.label}>Cantidad</label>
           <div className={styles.quantitySelector}>
-            <button 
+            <button
               className={styles.quantityButton}
-              onClick={() => handleQuantityChange(-1)}
+              onMouseDown={() => startPress(-1)}
+              onMouseUp={stopPress}
+              onMouseLeave={stopPress}
+              onTouchStart={(e) => { e.preventDefault(); startPress(-1); }}
+              onTouchEnd={stopPress}
+              onClick={() => { if (!isLongPressRef.current) handleQuantityChange(-1); }}
               disabled={formData.quantity <= 1}
+              aria-label="Reducir cantidad"
             >
-              -
+              −
             </button>
             <input
               type="number"
               className={styles.quantityInput}
               value={formData.quantity || ''}
               onChange={handleQuantityInputChange}
+              onKeyDown={handleKeyDown}
               onBlur={handleQuantityBlur}
               min="1"
               placeholder="1"
+              aria-label="Cantidad"
             />
-            <button 
+            <button
               className={styles.quantityButton}
-              onClick={() => handleQuantityChange(1)}
+              onMouseDown={() => startPress(1)}
+              onMouseUp={stopPress}
+              onMouseLeave={stopPress}
+              onTouchStart={(e) => { e.preventDefault(); startPress(1); }}
+              onTouchEnd={stopPress}
+              onClick={() => { if (!isLongPressRef.current) handleQuantityChange(1); }}
+              aria-label="Aumentar cantidad"
             >
               +
             </button>

--- a/src/components/wizard/ConfirmEventStep.module.css
+++ b/src/components/wizard/ConfirmEventStep.module.css
@@ -14,11 +14,12 @@
 
 .confirmationCard {
   background: var(--color-bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   padding: 24px;
   width: 100%;
   max-width: 100%;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
 }
 
 .detailRow {
@@ -27,7 +28,7 @@
   align-items: center;
   margin-bottom: 16px;
   padding: 12px 0;
-  border-bottom: 1px solid var(--color-border-light);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .detailRow:last-child {
@@ -74,7 +75,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 12px 0;
-  border-bottom: 1px solid var(--color-border-light);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .prizeItem:last-child {
@@ -100,44 +101,44 @@
     min-height: 300px;
     padding: 16px 0;
   }
-  
+
   .title {
     font-size: 24px;
     margin-bottom: 20px;
   }
-  
+
   .confirmationCard {
     padding: 24px;
   }
-  
+
   .detailRow {
     flex-direction: column;
     align-items: flex-start;
     gap: 4px;
     padding: 16px 0;
   }
-  
+
   .label {
     font-size: 13px;
   }
-  
+
   .value {
     font-size: 15px;
     text-align: left;
     margin-left: 0;
   }
-  
+
   .prizeItem {
     flex-direction: column;
     align-items: flex-start;
     gap: 4px;
   }
-  
+
   .prizeValue {
     text-align: left;
     margin-left: 0;
   }
-  
+
   .sectionLabel {
     font-size: 18px;
     margin-bottom: 16px;
@@ -149,27 +150,27 @@
     font-size: 22px;
     margin-bottom: 16px;
   }
-  
+
   .confirmationCard {
     padding: 20px;
   }
-  
+
   .label {
     font-size: 12px;
   }
-  
+
   .value {
     font-size: 14px;
   }
-  
+
   .prizeNumber {
     font-size: 13px;
   }
-  
+
   .prizeValue {
     font-size: 14px;
   }
-  
+
   .sectionLabel {
     font-size: 16px;
     margin-bottom: 12px;

--- a/src/components/wizard/CreateEventWizard.tsx
+++ b/src/components/wizard/CreateEventWizard.tsx
@@ -36,7 +36,7 @@ const CreateEventWizard: React.FC = () => {
   const [eventData, setEventData] = useState<EventData | null>(null);
   const [showSuccess, setShowSuccess] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
-  
+
   // Refs to trigger step validation
   const eventTypeStepRef = React.useRef<EventTypeStepRef>(null);
   const eventDataStepRef = React.useRef<EventDataStepRef>(null);
@@ -48,7 +48,7 @@ const CreateEventWizard: React.FC = () => {
       if (prev) {
         return { ...prev, ...data };
       }
-      
+
       // Initialize based on event type
       if (data.type === 'food_sale') {
         return {
@@ -102,18 +102,18 @@ const CreateEventWizard: React.FC = () => {
 
   const handleCreateEvent = async () => {
     setIsCreating(true);
-    
+
     try {
       // Simulate API call delay
       await new Promise(resolve => setTimeout(resolve, 1500));
-      
+
       // TODO: Replace with API call to save event data
       void eventData;
 
       // Show success screen
       setIsCreating(false);
       setShowSuccess(true);
-      
+
     } catch (error) {
       console.error('Error creating event:', error);
       setIsCreating(false);
@@ -202,10 +202,10 @@ const CreateEventWizard: React.FC = () => {
               </button>
             </div>
           )}
-          
+
           {/* Page Title */}
           <h1 className={styles.pageTitle}>Crear evento</h1>
-          
+
           <ProgressIndicator currentStep={currentStep} totalSteps={totalSteps} />
           {renderCurrentStep()}
           <ActionButtons

--- a/src/components/wizard/EventDataStep.module.css
+++ b/src/components/wizard/EventDataStep.module.css
@@ -14,11 +14,12 @@
 
 .formCard {
   background: var(--color-bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   padding: 24px;
   width: 100%;
   max-width: 100%;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
 }
 
 .fieldGroup {
@@ -52,29 +53,30 @@
 
 .label {
   display: block;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
   text-align: left;
+  letter-spacing: 0.1px;
 }
 
 .input {
   width: 100%;
-  padding: 16px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: var(--radius-lg);
   font-size: 16px;
   background-color: var(--color-bg-tertiary);
   color: var(--color-text-primary);
-  transition: border-color 0.3s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
   box-sizing: border-box;
 }
 
 .input:focus {
   outline: none;
-  border: 1px solid var(--color-primary);
-  box-shadow: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-light);
 }
 
 .input:focus-visible {
@@ -305,39 +307,39 @@
     min-height: 300px;
     padding: 16px 0;
   }
-  
+
   .title {
     font-size: 24px;
     margin-bottom: 20px;
   }
-  
+
   .formCard {
     padding: 24px;
   }
-  
+
   .twoColumnRow {
     grid-template-columns: 1fr;
     gap: 16px;
   }
-  
+
   .twoColumnRow .fieldGroup {
     margin-bottom: 16px;
   }
-  
+
   .twoColumnRow .fieldGroup:last-child {
     margin-bottom: 0;
   }
-  
+
   .toggleFieldGroup .toggleContainer {
     margin-top: 0;
     height: auto;
   }
-  
+
   .dateRow {
     grid-template-columns: 1fr;
     gap: 16px;
   }
-  
+
   .toggleLabel {
     font-size: 14px;
   }
@@ -348,52 +350,52 @@
     font-size: 22px;
     margin-bottom: 16px;
   }
-  
+
   .formCard {
     padding: 20px;
   }
-  
+
   .input {
     font-size: 15px;
     padding: 10px 14px;
   }
-  
+
   .prizeItemWrapper {
     margin-bottom: 20px;
   }
-  
+
   .prizeItem {
     flex-direction: column;
     gap: 12px;
   }
-  
+
   .removePrizeButton {
     align-self: stretch;
     height: 48px;
   }
-  
+
   .addPrizeButton {
     margin-top: 20px;
   }
-  
+
   .prizesSection {
     margin-top: 24px;
   }
-  
+
   .sectionLabel {
     font-size: 18px;
     margin-bottom: 20px;
   }
-  
+
   .foodItemWrapper {
     margin-bottom: 20px;
   }
-  
+
   .foodItemRow {
     grid-template-columns: 1fr;
     gap: 12px;
   }
-  
+
   .removePrizeButton {
     width: 100%;
     justify-content: center;

--- a/src/components/wizard/EventDataStep.tsx
+++ b/src/components/wizard/EventDataStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useImperativeHandle, forwardRef } from 'react';
+import { Trash2 } from 'lucide-react';
 import DatePicker from '@/components/DatePicker';
 import type { FoodItem } from './CreateEventWizard';
 import styles from './EventDataStep.module.css';
@@ -38,7 +39,7 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
   ({ initialData, onNext, onBack }, ref) => {
     const eventType = initialData?.type || 'raffle';
     const isFoodSale = eventType === 'food_sale';
-    
+
     const [formData, setFormData] = useState({
       name: initialData?.name || '',
       numberValue: initialData?.numberValue || '',
@@ -159,7 +160,7 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
         }));
       }
     };
-    
+
     const getPrizeLabel = (index: number): string => {
       const labels = [
         'Primer premio',
@@ -237,7 +238,7 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
     const handleFoodItemChange = (index: number, field: 'name' | 'price', value: string) => {
       setFormData(prev => ({
         ...prev,
-        foodItems: prev.foodItems.map((item, i) => 
+        foodItems: prev.foodItems.map((item, i) =>
           i === index ? { ...item, [field]: value } : item
         )
       }));
@@ -260,201 +261,191 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
     return (
       <div className={styles.container}>
         <h1 className={styles.title}>Datos Generales</h1>
-        
+
         <div className={styles.formCard}>
-            {/* Event Name - Always visible */}
+          {/* Event Name - Always visible */}
+          <div className={styles.fieldGroup}>
+            <label className={styles.label}>Nombre del evento</label>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) => handleInputChange('name', e.target.value)}
+              className={`${styles.input} ${errors.name ? styles.inputError : ''}`}
+              placeholder={isFoodSale ? "Ej: Venta de pollo asado" : "Ej: Rifa Aniversario del Club"}
+            />
+            {errors.name && <span className={styles.errorText}>{errors.name}</span>}
+          </div>
+
+          {/* Raffle-specific fields */}
+          {!isFoodSale && (
+            <>
+              <div className={styles.twoColumnRow}>
+                <div className={styles.fieldGroup}>
+                  <label className={styles.label}>Valor del número</label>
+                  <input
+                    type="text"
+                    value={formData.numberValue}
+                    onChange={(e) => handleInputChange('numberValue', e.target.value)}
+                    className={`${styles.input} ${errors.numberValue ? styles.inputError : ''}`}
+                    placeholder="Ej: $500"
+                  />
+                  {errors.numberValue && <span className={styles.errorText}>{errors.numberValue}</span>}
+                </div>
+
+                <div className={styles.fieldGroup}>
+                  <label className={styles.label}>Cantidad de números totales (opcional)</label>
+                  <input
+                    type="text"
+                    value={formData.totalNumbers}
+                    onChange={(e) => handleInputChange('totalNumbers', e.target.value)}
+                    className={`${styles.input} ${errors.totalNumbers ? styles.inputError : ''}`}
+                    placeholder="Ej: 1000"
+                    disabled={formData.autoAdjust}
+                  />
+                  {errors.totalNumbers && <span className={styles.errorText}>{errors.totalNumbers}</span>}
+                </div>
+              </div>
+
+              <div className={`${styles.fieldGroup} ${styles.toggleFieldGroup}`}>
+                <div className={styles.toggleContainer}>
+                  <label className={styles.toggle}>
+                    <input
+                      type="checkbox"
+                      checked={formData.autoAdjust}
+                      onChange={(e) => handleInputChange('autoAdjust', e.target.checked)}
+                      className={styles.toggleInput}
+                    />
+                    <span className={styles.toggleSlider}></span>
+                  </label>
+                  <span className={styles.toggleLabel}>
+                    Calcular cantidad total automáticamente
+                  </span>
+                </div>
+              </div>
+            </>
+          )}
+
+          <div className={styles.dateRow}>
             <div className={styles.fieldGroup}>
-              <label className={styles.label}>Nombre del evento</label>
-              <input
-                type="text"
-                value={formData.name}
-                onChange={(e) => handleInputChange('name', e.target.value)}
-                className={`${styles.input} ${errors.name ? styles.inputError : ''}`}
-                placeholder={isFoodSale ? "Ej: Venta de pollo asado" : "Ej: Rifa Aniversario del Club"}
+              <label className={styles.label}>Fecha de inicio</label>
+              <DatePicker
+                selected={formData.startDate}
+                onChange={(date) => handleInputChange('startDate', date)}
+                placeholder="DD/MM/AA"
+                error={!!errors.startDate}
               />
-              {errors.name && <span className={styles.errorText}>{errors.name}</span>}
+              {errors.startDate && <span className={styles.errorText}>{errors.startDate}</span>}
             </div>
 
-            {/* Raffle-specific fields */}
-            {!isFoodSale && (
-              <>
-                <div className={styles.twoColumnRow}>
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.label}>Valor del número</label>
-                    <input
-                      type="text"
-                      value={formData.numberValue}
-                      onChange={(e) => handleInputChange('numberValue', e.target.value)}
-                      className={`${styles.input} ${errors.numberValue ? styles.inputError : ''}`}
-                      placeholder="Ej: $500"
-                    />
-                    {errors.numberValue && <span className={styles.errorText}>{errors.numberValue}</span>}
-                  </div>
+            <div className={styles.fieldGroup}>
+              <label className={styles.label}>Fecha de finalización</label>
+              <DatePicker
+                selected={formData.endDate}
+                onChange={(date) => handleInputChange('endDate', date)}
+                placeholder="DD/MM/AA"
+                error={!!errors.endDate}
+              />
+              {errors.endDate && <span className={styles.errorText}>{errors.endDate}</span>}
+            </div>
+          </div>
 
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.label}>Cantidad de números totales (opcional)</label>
-                    <input
-                      type="text"
-                      value={formData.totalNumbers}
-                      onChange={(e) => handleInputChange('totalNumbers', e.target.value)}
-                      className={`${styles.input} ${errors.totalNumbers ? styles.inputError : ''}`}
-                      placeholder="Ej: 1000"
-                      disabled={formData.autoAdjust}
-                    />
-                    {errors.totalNumbers && <span className={styles.errorText}>{errors.totalNumbers}</span>}
-                  </div>
-                </div>
+          {/* Prizes section for raffles */}
+          {!isFoodSale && (
+            <div className={styles.prizesSection}>
+              <h2 className={styles.sectionLabel}>🏆 Premios</h2>
 
-                <div className={`${styles.fieldGroup} ${styles.toggleFieldGroup}`}>
-                  <div className={styles.toggleContainer}>
-                    <label className={styles.toggle}>
+              {formData.prizes.map((prize, index) => (
+                <div key={index} className={styles.prizeItemWrapper}>
+                  <label className={styles.label}>
+                    {getPrizeLabel(index)}
+                  </label>
+                  <div className={styles.prizeItem}>
+                    <div className={styles.prizeItemInput}>
                       <input
-                        type="checkbox"
-                        checked={formData.autoAdjust}
-                        onChange={(e) => handleInputChange('autoAdjust', e.target.checked)}
-                        className={styles.toggleInput}
+                        type="text"
+                        value={prize}
+                        onChange={(e) => handlePrizeChange(index, e.target.value)}
+                        className={`${styles.input} ${errors[`prize_${index}`] ? styles.inputError : ''}`}
+                        placeholder={index === 0 ? "Ej: Bicicleta rodado 29" : index === 1 ? "Ej: Smart TV 50 pulgadas" : "Ej: Vale de compra $10.000"}
                       />
-                      <span className={styles.toggleSlider}></span>
-                    </label>
-                    <span className={styles.toggleLabel}>
-                      Calcular cantidad total automáticamente
-                    </span>
+                      {errors[`prize_${index}`] && <span className={styles.errorText}>{errors[`prize_${index}`]}</span>}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRemovePrize(index)}
+                      className={styles.removePrizeButton}
+                      disabled={index === 0}
+                    >
+                      <Trash2 size={18} />
+                    </button>
                   </div>
                 </div>
-              </>
-            )}
+              ))}
 
-            <div className={styles.dateRow}>
-              <div className={styles.fieldGroup}>
-                <label className={styles.label}>Fecha de inicio</label>
-                <DatePicker
-                  selected={formData.startDate}
-                  onChange={(date) => handleInputChange('startDate', date)}
-                  placeholder="DD/MM/AA"
-                  error={!!errors.startDate}
-                />
-                {errors.startDate && <span className={styles.errorText}>{errors.startDate}</span>}
-              </div>
-
-              <div className={styles.fieldGroup}>
-                <label className={styles.label}>Fecha de finalización</label>
-                <DatePicker
-                  selected={formData.endDate}
-                  onChange={(date) => handleInputChange('endDate', date)}
-                  placeholder="DD/MM/AA"
-                  error={!!errors.endDate}
-                />
-                {errors.endDate && <span className={styles.errorText}>{errors.endDate}</span>}
-              </div>
+              <button
+                type="button"
+                onClick={handleAddPrize}
+                className={`btn btn-tertiary btn-full ${styles.addPrizeButton}`}
+                disabled={formData.prizes.length >= 10}
+              >
+                Agregar premio {formData.prizes.length >= 10 ? '(máximo 10)' : ''}
+              </button>
             </div>
+          )}
 
-            {/* Prizes section for raffles */}
-            {!isFoodSale && (
-              <div className={styles.prizesSection}>
-                <h2 className={styles.sectionLabel}>🏆 Premios</h2>
-                
-                {formData.prizes.map((prize, index) => (
-                  <div key={index} className={styles.prizeItemWrapper}>
-                    <label className={styles.label}>
-                      {getPrizeLabel(index)}
-                    </label>
-                    <div className={styles.prizeItem}>
-                      <div className={styles.prizeItemInput}>
-                        <input
-                          type="text"
-                          value={prize}
-                          onChange={(e) => handlePrizeChange(index, e.target.value)}
-                          className={`${styles.input} ${errors[`prize_${index}`] ? styles.inputError : ''}`}
-                          placeholder={index === 0 ? "Ej: Bicicleta rodado 29" : index === 1 ? "Ej: Smart TV 50 pulgadas" : "Ej: Vale de compra $10.000"}
-                        />
-                        {errors[`prize_${index}`] && <span className={styles.errorText}>{errors[`prize_${index}`]}</span>}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => handleRemovePrize(index)}
-                        className={styles.removePrizeButton}
-                        disabled={index === 0}
-                      >
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M3 6H5H21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                          <path d="M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6H19Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                          <path d="M10 11V17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                          <path d="M14 11V17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                ))}
-                
-                <button
-                  type="button"
-                  onClick={handleAddPrize}
-                  className={`btn btn-tertiary btn-full ${styles.addPrizeButton}`}
-                  disabled={formData.prizes.length >= 10}
-                >
-                  Agregar premio {formData.prizes.length >= 10 ? '(máximo 10)' : ''}
-                </button>
-              </div>
-            )}
+          {/* Food items section for food sales */}
+          {isFoodSale && (
+            <div className={styles.prizesSection}>
+              <h2 className={styles.sectionLabel}>🍽️ Menú</h2>
 
-            {/* Food items section for food sales */}
-            {isFoodSale && (
-              <div className={styles.prizesSection}>
-                <h2 className={styles.sectionLabel}>🍽️ Menú</h2>
-                
-                {formData.foodItems.map((item, index) => (
-                  <div key={index} className={styles.foodItemWrapper}>
-                    <label className={styles.label}>
-                      Plato {index + 1}
-                    </label>
-                    <div className={styles.foodItemRow}>
-                      <div className={styles.foodItemName}>
-                        <input
-                          type="text"
-                          value={item.name}
-                          onChange={(e) => handleFoodItemChange(index, 'name', e.target.value)}
-                          className={`${styles.input} ${errors[`foodItem_${index}_name`] ? styles.inputError : ''}`}
-                          placeholder={index === 0 ? "Ej: Pollo asado con papas" : index === 1 ? "Ej: Empanadas de carne" : "Ej: Locro"}
-                        />
-                        {errors[`foodItem_${index}_name`] && <span className={styles.errorText}>{errors[`foodItem_${index}_name`]}</span>}
-                      </div>
-                      <div className={styles.foodItemPrice}>
-                        <input
-                          type="text"
-                          value={item.price}
-                          onChange={(e) => handleFoodItemChange(index, 'price', e.target.value)}
-                          className={`${styles.input} ${errors[`foodItem_${index}_price`] ? styles.inputError : ''}`}
-                          placeholder="Ej: $3500"
-                        />
-                        {errors[`foodItem_${index}_price`] && <span className={styles.errorText}>{errors[`foodItem_${index}_price`]}</span>}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => handleRemoveFoodItem(index)}
-                        className={styles.removePrizeButton}
-                        disabled={formData.foodItems.length === 1}
-                      >
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M3 6H5H21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                          <path d="M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6H19Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                          <path d="M10 11V17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                          <path d="M14 11V17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                        </svg>
-                      </button>
+              {formData.foodItems.map((item, index) => (
+                <div key={index} className={styles.foodItemWrapper}>
+                  <label className={styles.label}>
+                    Plato {index + 1}
+                  </label>
+                  <div className={styles.foodItemRow}>
+                    <div className={styles.foodItemName}>
+                      <input
+                        type="text"
+                        value={item.name}
+                        onChange={(e) => handleFoodItemChange(index, 'name', e.target.value)}
+                        className={`${styles.input} ${errors[`foodItem_${index}_name`] ? styles.inputError : ''}`}
+                        placeholder={index === 0 ? "Ej: Pollo asado con papas" : index === 1 ? "Ej: Empanadas de carne" : "Ej: Locro"}
+                      />
+                      {errors[`foodItem_${index}_name`] && <span className={styles.errorText}>{errors[`foodItem_${index}_name`]}</span>}
                     </div>
+                    <div className={styles.foodItemPrice}>
+                      <input
+                        type="text"
+                        value={item.price}
+                        onChange={(e) => handleFoodItemChange(index, 'price', e.target.value)}
+                        className={`${styles.input} ${errors[`foodItem_${index}_price`] ? styles.inputError : ''}`}
+                        placeholder="Ej: $3500"
+                      />
+                      {errors[`foodItem_${index}_price`] && <span className={styles.errorText}>{errors[`foodItem_${index}_price`]}</span>}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveFoodItem(index)}
+                      className={styles.removePrizeButton}
+                      disabled={formData.foodItems.length === 1}
+                    >
+                      <Trash2 size={18} />
+                    </button>
                   </div>
-                ))}
-                
-                <button
-                  type="button"
-                  onClick={handleAddFoodItem}
-                  className={`btn btn-tertiary btn-full ${styles.addPrizeButton}`}
-                  disabled={formData.foodItems.length >= 20}
-                >
-                  Agregar plato {formData.foodItems.length >= 20 ? '(máximo 20)' : ''}
-                </button>
-              </div>
-            )}
+                </div>
+              ))}
+
+              <button
+                type="button"
+                onClick={handleAddFoodItem}
+                className={`btn btn-tertiary btn-full ${styles.addPrizeButton}`}
+                disabled={formData.foodItems.length >= 20}
+              >
+                Agregar plato {formData.foodItems.length >= 20 ? '(máximo 20)' : ''}
+              </button>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/components/wizard/EventTypeStep.module.css
+++ b/src/components/wizard/EventTypeStep.module.css
@@ -21,7 +21,7 @@
 
 .optionBox {
   background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
+  border: 1px solid rgba(255, 255, 255, 0.09);
   border-radius: var(--radius-xl);
   padding: 24px;
   cursor: pointer;
@@ -33,20 +33,22 @@
   min-height: 180px;
   position: relative;
   overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .optionBox:hover {
-  border-color: var(--color-primary);
+  border-color: rgba(90, 200, 250, 0.5);
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(90, 200, 250, 0.2);
+  box-shadow: 0 8px 28px rgba(90, 200, 250, 0.18);
+  background: var(--color-bg-tertiary);
 }
 
 .optionBox.selected {
-  border-color: var(--color-primary);
-  background: linear-gradient(135deg, var(--color-primary) 0%, #007AFF 100%);
+  border-color: rgba(90, 200, 250, 0.6);
+  background: linear-gradient(135deg, rgba(90, 200, 250, 0.15) 0%, rgba(0, 122, 255, 0.15) 100%);
   color: var(--color-white);
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(90, 200, 250, 0.35);
+  box-shadow: 0 8px 28px rgba(90, 200, 250, 0.25);
 }
 
 .iconContainer {
@@ -83,7 +85,7 @@
 }
 
 .optionBox.selected .optionText {
-  color: var(--color-white);
+  color: var(--color-primary);
 }
 
 /* Responsive */
@@ -91,7 +93,7 @@
   .optionsGrid {
     gap: 24px;
   }
-  
+
   .optionBox {
     padding: 32px;
     min-height: 200px;
@@ -103,7 +105,7 @@
     grid-template-columns: 1fr;
     gap: 16px;
   }
-  
+
   .optionBox {
     min-height: 160px;
   }
@@ -114,15 +116,15 @@
     padding: 20px;
     min-height: 140px;
   }
-  
+
   .title {
     font-size: 20px;
   }
-  
+
   .optionText {
     font-size: 14px;
   }
-  
+
   .emojiIcon {
     font-size: 67px;
   }

--- a/src/components/wizard/EventTypeStep.tsx
+++ b/src/components/wizard/EventTypeStep.tsx
@@ -38,9 +38,9 @@ const EventTypeStep = forwardRef<EventTypeStepRef, EventTypeStepProps>(
         <h1 className={styles.title}>
           ¿Qué tipo de evento querés crear?
         </h1>
-        
+
         <div className={styles.optionsGrid}>
-          <div 
+          <div
             className={`${styles.optionBox} ${selectedType === 'food_sale' ? styles.selected : ''}`}
             onClick={() => handleTypeChange('food_sale')}
           >
@@ -49,8 +49,8 @@ const EventTypeStep = forwardRef<EventTypeStepRef, EventTypeStepProps>(
             </div>
             <span className={styles.optionText}>Venta de comida</span>
           </div>
-          
-          <div 
+
+          <div
             className={`${styles.optionBox} ${selectedType === 'raffle' ? styles.selected : ''}`}
             onClick={() => handleTypeChange('raffle')}
           >

--- a/src/components/wizard/ProgressIndicator.module.css
+++ b/src/components/wizard/ProgressIndicator.module.css
@@ -1,76 +1,89 @@
 .container {
-  margin-bottom: 12px;
+  margin-bottom: var(--space-2xl);
 }
 
-.progressBars {
+.stepsRow {
   display: flex;
-  gap: 12px;
-  max-width: 180px;
+  align-items: center;
 }
 
-.progressBar {
-  height: 8px;
-  border-radius: var(--radius-md);
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.stepCircle {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.stepCircle.pending {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-tertiary);
+}
+
+.stepCircle.active {
+  background: linear-gradient(135deg, var(--color-primary) 0%, #007AFF 100%);
+  color: white;
+  box-shadow:
+    0 0 0 4px var(--color-primary-light),
+    0 4px 14px rgba(90, 200, 250, 0.4);
+}
+
+.stepCircle.completed {
+  background: linear-gradient(135deg, var(--color-primary) 0%, #007AFF 100%);
+  color: white;
+}
+
+.connector {
   flex: 1;
-  position: relative;
-  overflow: hidden;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  background-color: var(--color-bg-tertiary);
+  height: 2px;
+  margin: 0 10px;
+  margin-bottom: 22px;
+  background-color: var(--color-border-light);
+  transition: background-color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.progressBar::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, 
-    rgba(255, 255, 255, 0) 0%, 
-    rgba(255, 255, 255, 0.15) 50%, 
-    rgba(255, 255, 255, 0) 100%);
-  transform: translateX(-100%);
-}
-
-.active {
+.connectorCompleted {
   background: linear-gradient(90deg, var(--color-primary) 0%, #007AFF 100%);
-  box-shadow: 0 2px 8px rgba(90, 200, 250, 0.35);
-  animation: fillIn 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
-.active::before {
-  animation: shimmer 2s infinite;
+.stepLabel {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+  transition: color 0.3s ease;
+  white-space: nowrap;
 }
 
-.inactive {
-  background-color: var(--color-bg-tertiary);
-  transform: scale(1);
+.stepLabelActive {
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
-.progressBar:hover {
-  transform: scaleY(1.2);
-}
-
-.active:hover {
-  box-shadow: 0 3px 12px rgba(90, 200, 250, 0.45);
-}
-
-@keyframes fillIn {
-  from {
-    transform: scaleX(0);
-    transform-origin: left;
+@media (max-width: 480px) {
+  .stepCircle {
+    width: 30px;
+    height: 30px;
+    font-size: 12px;
   }
-  to {
-    transform: scaleX(1);
-    transform-origin: left;
-  }
-}
 
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
+  .connector {
+    margin: 0 6px;
+    margin-bottom: 22px;
   }
-  100% {
-    transform: translateX(100%);
+
+  .stepLabel {
+    font-size: 10px;
   }
 }

--- a/src/components/wizard/ProgressIndicator.tsx
+++ b/src/components/wizard/ProgressIndicator.tsx
@@ -6,24 +6,66 @@ import styles from './ProgressIndicator.module.css';
 interface ProgressIndicatorProps {
   currentStep: number;
   totalSteps: number;
+  stepLabels?: string[];
 }
 
-const ProgressIndicator: React.FC<ProgressIndicatorProps> = ({ currentStep, totalSteps }) => {
+const ProgressIndicator: React.FC<ProgressIndicatorProps> = ({
+  currentStep,
+  totalSteps,
+  stepLabels = ['Tipo', 'Datos', 'Confirmar'],
+}) => {
   return (
     <div className={styles.container}>
-      <div className={styles.progressBars}>
-        {Array.from({ length: totalSteps }, (_, index) => (
-          <div
-            key={index}
-            className={`${styles.progressBar} ${
-              index < currentStep ? styles.active : styles.inactive
-            }`}
-          />
-        ))}
+      <div className={styles.stepsRow}>
+        {Array.from({ length: totalSteps }, (_, index) => {
+          const stepNumber = index + 1;
+          const isCompleted = stepNumber < currentStep;
+          const isActive = stepNumber === currentStep;
+
+          return (
+            <React.Fragment key={index}>
+              <div className={styles.step}>
+                <div
+                  className={`${styles.stepCircle} ${
+                    isCompleted ? styles.completed : isActive ? styles.active : styles.pending
+                  }`}
+                >
+                  {isCompleted ? (
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
+                      <path
+                        d="M20 6L9 17L4 12"
+                        stroke="currentColor"
+                        strokeWidth="2.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  ) : (
+                    <span>{stepNumber}</span>
+                  )}
+                </div>
+                <span
+                  className={`${styles.stepLabel} ${
+                    isActive || isCompleted ? styles.stepLabelActive : ''
+                  }`}
+                >
+                  {stepLabels[index] ?? `Paso ${stepNumber}`}
+                </span>
+              </div>
+
+              {index < totalSteps - 1 && (
+                <div
+                  className={`${styles.connector} ${
+                    stepNumber < currentStep ? styles.connectorCompleted : ''
+                  }`}
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
       </div>
     </div>
   );
 };
 
 export default ProgressIndicator;
-

--- a/src/components/wizard/QuantityStepper.module.css
+++ b/src/components/wizard/QuantityStepper.module.css
@@ -1,0 +1,70 @@
+/* QuantityStepper.module.css */
+
+.stepper {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-tertiary);
+  overflow: hidden;
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 48px;
+  height: 100%;
+  background: transparent;
+  border: none;
+  color: var(--color-text-primary);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color var(--transition-base);
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+}
+
+.btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.btn:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.input {
+  flex: 1;
+  height: 100%;
+  background: transparent;
+  border: none;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+  outline: none;
+  min-width: 0;
+  /* Hide native number spinners */
+  -moz-appearance: textfield;
+}
+
+.input::-webkit-outer-spin-button,
+.input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.input::placeholder {
+  color: var(--color-text-tertiary);
+  font-weight: var(--font-weight-normal);
+}

--- a/src/components/wizard/QuantityStepper.tsx
+++ b/src/components/wizard/QuantityStepper.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { useRef } from 'react';
+import styles from './QuantityStepper.module.css';
+
+interface Props {
+    id?: string;
+    value: number;
+    onChange: (val: number) => void;
+    min?: number;
+}
+
+const QuantityStepper: React.FC<Props> = ({ id, value, onChange, min = 1 }) => {
+    // Keep a ref so setInterval always reads the latest value (avoids stale closure)
+    const valueRef = useRef(value);
+    valueRef.current = value;
+
+    const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const isLongPressRef = useRef(false);
+
+    const change = (delta: number) => {
+        onChange(Math.max(min, valueRef.current + delta));
+    };
+
+    const startPress = (delta: number) => {
+        isLongPressRef.current = false;
+        pressTimerRef.current = setTimeout(() => {
+            isLongPressRef.current = true;
+            pressIntervalRef.current = setInterval(() => change(delta), 80);
+        }, 400);
+    };
+
+    const stopPress = () => {
+        if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
+        if (pressIntervalRef.current) clearInterval(pressIntervalRef.current);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'ArrowUp' || e.key === '+') {
+            e.preventDefault();
+            onChange(Math.max(min, value + 1));
+        } else if (e.key === 'ArrowDown' || e.key === '-') {
+            e.preventDefault();
+            onChange(Math.max(min, value - 1));
+        }
+    };
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const raw = e.target.value;
+        if (raw === '') { onChange(0); return; }
+        const n = parseInt(raw, 10);
+        if (!isNaN(n) && n >= min) onChange(n);
+    };
+
+    const handleBlur = () => {
+        if (value < min) onChange(min);
+    };
+
+    return (
+        <div className={styles.stepper}>
+            <button
+                type="button"
+                className={styles.btn}
+                onMouseDown={() => startPress(-1)}
+                onMouseUp={stopPress}
+                onMouseLeave={stopPress}
+                onTouchStart={(e) => { e.preventDefault(); startPress(-1); }}
+                onTouchEnd={stopPress}
+                onClick={() => { if (!isLongPressRef.current) change(-1); }}
+                disabled={value <= min}
+                aria-label="Reducir cantidad"
+            >
+                −
+            </button>
+            <input
+                id={id}
+                type="number"
+                className={styles.input}
+                value={value || ''}
+                onChange={handleInputChange}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                min={min}
+                placeholder={String(min)}
+                aria-label="Cantidad"
+            />
+            <button
+                type="button"
+                className={styles.btn}
+                onMouseDown={() => startPress(1)}
+                onMouseUp={stopPress}
+                onMouseLeave={stopPress}
+                onTouchStart={(e) => { e.preventDefault(); startPress(1); }}
+                onTouchEnd={stopPress}
+                onClick={() => { if (!isLongPressRef.current) change(1); }}
+                aria-label="Aumentar cantidad"
+            >
+                +
+            </button>
+        </div>
+    );
+};
+
+export default QuantityStepper;

--- a/src/components/wizard/RegisterSaleModal.module.css
+++ b/src/components/wizard/RegisterSaleModal.module.css
@@ -1,0 +1,326 @@
+/* RegisterSaleModal.module.css — Desktop Dialog only */
+
+/* Hidden on mobile */
+.overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: var(--space-lg);
+}
+
+.modal {
+    background: var(--color-bg-secondary);
+    border-radius: var(--radius-xl);
+    width: 100%;
+    max-width: 600px;
+    max-height: 90vh;
+    overflow-y: auto;
+    border: 1px solid var(--color-border-light);
+}
+
+/* Header */
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px 24px 0 24px;
+}
+
+.title {
+    margin: 0;
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-primary);
+}
+
+.closeBtn {
+    background: none;
+    border: none;
+    padding: var(--space-xs);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--transition-base);
+}
+
+.closeBtn:hover {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+}
+
+/* Content */
+.content {
+    padding: 24px;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.formCard {
+    background: var(--color-bg-tertiary);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border-light);
+    padding: var(--space-xl);
+    margin-bottom: var(--space-xl);
+}
+
+.fieldGroup {
+    margin-bottom: 24px;
+}
+
+.fieldGroup:last-of-type {
+    margin-bottom: 0;
+}
+
+.fieldGroupError .label {
+    color: var(--color-error);
+}
+
+.fieldGroupError .input {
+    border-color: var(--color-error);
+}
+
+.label {
+    display: block;
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+    margin-bottom: var(--space-xs);
+}
+
+.input {
+    width: 100%;
+    padding: var(--space-md);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-base);
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text-primary);
+    transition: all var(--transition-base);
+    box-sizing: border-box;
+}
+
+.input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px var(--color-primary-light);
+}
+
+.input::placeholder {
+    color: var(--color-text-tertiary);
+}
+
+.hint {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-tertiary);
+    margin-top: 4px;
+    margin-bottom: 0;
+}
+
+.error {
+    font-size: var(--font-size-sm);
+    color: var(--color-error);
+    margin-top: 4px;
+    margin-bottom: 0;
+}
+
+/* Event List */
+.eventList {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    margin-bottom: var(--space-lg);
+}
+
+.eventCard {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-lg);
+    width: 100%;
+    padding: var(--space-lg);
+    background: var(--color-bg-tertiary);
+    border: 2px solid var(--color-border-light);
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    transition: all var(--transition-base);
+    text-align: left;
+}
+
+.eventCard:hover {
+    border-color: var(--color-border);
+    background: var(--color-bg-secondary);
+}
+
+.eventCardSelected {
+    border-color: var(--color-primary);
+    background: var(--color-primary-light);
+}
+
+.eventCardContent {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+}
+
+.eventTitle {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.eventStatus {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-success);
+}
+
+.statusDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--color-success);
+}
+
+.checkIcon {
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+/* Dish Selector */
+.dishSelector {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-md);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--space-xs);
+}
+
+.dishHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-xs);
+}
+
+.dishName {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+}
+
+.dishPrice {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary);
+}
+
+/* Actions */
+.actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+}
+
+.cancelBtn {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md);
+    padding: 14px var(--space-xl);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+    transition: all var(--transition-base);
+}
+
+.cancelBtn:hover {
+    background: var(--color-border-light);
+}
+
+.primaryBtn {
+    background: var(--color-white);
+    color: var(--color-bg-primary);
+    border: none;
+    border-radius: var(--radius-lg);
+    padding: 14px var(--space-xl);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+    transition: all var(--transition-base);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.primaryBtn:hover {
+    background: var(--color-gray-900);
+    transform: translateY(-1px);
+}
+
+.primaryBtn:active {
+    transform: scale(0.98);
+}
+
+.primaryBtn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+}
+
+/* Success Screen */
+.successScreen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: var(--space-md);
+    padding: var(--space-lg) 0;
+}
+
+.successIcon {
+    color: var(--color-success);
+    margin-bottom: var(--space-xs);
+}
+
+.successTitle {
+    margin: 0;
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-text-primary);
+}
+
+.successDesc {
+    margin: 0;
+    font-size: var(--font-size-base);
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    max-width: 380px;
+}
+
+.successDesc strong {
+    color: var(--color-text-primary);
+    font-weight: var(--font-weight-semibold);
+}
+
+/* Show only on desktop */
+@media (min-width: 768px) {
+    .overlay {
+        display: flex;
+    }
+}

--- a/src/components/wizard/RegisterSaleModal.tsx
+++ b/src/components/wizard/RegisterSaleModal.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+/**
+ * RegisterSaleModal (Desktop)
+ *
+ * Dialog modal presentation of the "Registrar Venta" wizard.
+ * Receives all state and callbacks from RegisterSaleWizard.
+ * Hidden on mobile via CSS.
+ */
+
+import React from 'react';
+import { Check, CheckCircle, X } from 'lucide-react';
+import type { SaleEvent } from './RegisterSaleWizard';
+import type { SaleDetailsErrors } from '@/utils/registerSaleSchema';
+import QuantityStepper from './QuantityStepper';
+import styles from './RegisterSaleModal.module.css';
+
+interface Props {
+    step: 1 | 2;
+    isSuccess: boolean;
+    activeEvents: SaleEvent[];
+    currentEvent?: SaleEvent;
+    isFoodSale: boolean;
+    selectedEventId: string;
+    eventError?: string;
+    detailErrors: SaleDetailsErrors;
+    saleQuantity: number;
+    buyerName: string;
+    phone: string;
+    selectedDishes: Record<string, number>;
+    onClose: () => void;
+    onSelectEvent: (id: string) => void;
+    onContinue: () => void;
+    onBack: () => void;
+    onQuantityChange: (qty: number) => void;
+    onBuyerNameChange: (val: string) => void;
+    onPhoneChange: (val: string) => void;
+    onDishChange: (dishName: string, qty: number) => void;
+    onSubmit: (e: React.FormEvent) => void;
+}
+
+const RegisterSaleModal: React.FC<Props> = ({
+    step,
+    isSuccess,
+    activeEvents,
+    currentEvent,
+    isFoodSale,
+    selectedEventId,
+    eventError,
+    detailErrors,
+    saleQuantity,
+    buyerName,
+    phone,
+    selectedDishes,
+    onClose,
+    onSelectEvent,
+    onContinue,
+    onBack,
+    onQuantityChange,
+    onBuyerNameChange,
+    onPhoneChange,
+    onDishChange,
+    onSubmit,
+}) => {
+    return (
+        <div className={styles.overlay} onClick={onClose}>
+            <div
+                className={styles.modal}
+                onClick={(e) => e.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Registrar venta"
+            >
+                {/* ── Success Screen ────────────────────────────────────────── */}
+                {isSuccess && (
+                    <>
+                        <div className={styles.header}>
+                            <h2 className={styles.title}>Venta registrada</h2>
+                            <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Cerrar">
+                                <X size={24} />
+                            </button>
+                        </div>
+                        <div className={styles.content}>
+                            <div className={styles.successScreen}>
+                                <div className={styles.successIcon}>
+                                    <CheckCircle size={52} strokeWidth={1.5} />
+                                </div>
+                                <h2 className={styles.successTitle}>¡Todo listo!</h2>
+                                <p className={styles.successDesc}>
+                                    La venta de <strong>{buyerName}</strong> fue registrada correctamente en{' '}
+                                    <strong>{currentEvent?.name}</strong>.
+                                </p>
+                                <button type="button" className={styles.primaryBtn} onClick={onClose}>
+                                    Listo
+                                </button>
+                            </div>
+                        </div>
+                    </>
+                )}
+
+                {/* ── Step 1: Event Selection ───────────────────────────────── */}
+                {!isSuccess && step === 1 && (
+                    <>
+                        <div className={styles.header}>
+                            <h2 className={styles.title}>Seleccionar evento</h2>
+                            <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Cerrar">
+                                <X size={24} />
+                            </button>
+                        </div>
+
+                        <div className={styles.content}>
+                            <div className={styles.eventList}>
+                                {activeEvents.map((event) => (
+                                    <button
+                                        key={event.id}
+                                        type="button"
+                                        className={`${styles.eventCard} ${selectedEventId === event.id ? styles.eventCardSelected : ''}`}
+                                        onClick={() => onSelectEvent(event.id)}
+                                    >
+                                        <div className={styles.eventCardContent}>
+                                            <div className={styles.eventStatus}>
+                                                <span className={styles.statusDot} />
+                                                <span>ACTIVO</span>
+                                            </div>
+                                            <div className={styles.eventTitle}>{event.name}</div>
+                                        </div>
+                                        {selectedEventId === event.id && <Check size={24} className={styles.checkIcon} />}
+                                    </button>
+                                ))}
+                            </div>
+
+                            {eventError && <p className={styles.error}>{eventError}</p>}
+
+                            <div className={styles.actions}>
+                                <button type="button" className={styles.cancelBtn} onClick={onClose}>Cancelar</button>
+                                <button
+                                    type="button"
+                                    className={styles.primaryBtn}
+                                    onClick={onContinue}
+                                    disabled={!selectedEventId}
+                                >
+                                    Continuar
+                                </button>
+                            </div>
+                        </div>
+                    </>
+                )}
+
+                {/* ── Step 2: Sale Details ──────────────────────────────────── */}
+                {!isSuccess && step === 2 && (
+                    <>
+                        <div className={styles.header}>
+                            <h2 className={styles.title}>{currentEvent?.name}</h2>
+                            <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Cerrar">
+                                <X size={24} />
+                            </button>
+                        </div>
+
+                        <div className={styles.content}>
+                            <form onSubmit={onSubmit} className={styles.form} noValidate>
+                                <div className={styles.formCard}>
+                                    {isFoodSale && currentEvent?.dishes ? (
+                                        <div className={styles.fieldGroup}>
+                                            <label className={styles.label}>Seleccionar platos</label>
+                                            {currentEvent.dishes.map((dish) => (
+                                                <div key={dish.name} className={styles.dishSelector}>
+                                                    <div className={styles.dishHeader}>
+                                                        <span className={styles.dishName}>{dish.name}</span>
+                                                        <span className={styles.dishPrice}>${dish.price.toLocaleString()}</span>
+                                                    </div>
+                                                    <input
+                                                        type="number"
+                                                        min={0}
+                                                        value={selectedDishes[dish.name] ?? 0}
+                                                        onChange={(e) => onDishChange(dish.name, parseInt(e.target.value, 10) || 0)}
+                                                        className={styles.input}
+                                                        placeholder="Cantidad"
+                                                    />
+                                                </div>
+                                            ))}
+                                            {detailErrors.dishes && <p className={styles.error}>{detailErrors.dishes}</p>}
+                                        </div>
+                                    ) : (
+                                        <div className={styles.fieldGroup}>
+                                            <label className={styles.label}>Cantidad de números</label>
+                                            <QuantityStepper
+                                                value={saleQuantity}
+                                                onChange={onQuantityChange}
+                                                min={1}
+                                            />
+                                        </div>
+                                    )}
+
+                                    <div className={`${styles.fieldGroup} ${detailErrors.buyerName ? styles.fieldGroupError : ''}`}>
+                                        <label className={styles.label} htmlFor="modal-buyer">Nombre del comprador</label>
+                                        <input
+                                            id="modal-buyer"
+                                            type="text"
+                                            value={buyerName}
+                                            onChange={(e) => onBuyerNameChange(e.target.value)}
+                                            placeholder="Ej: María González"
+                                            className={styles.input}
+                                        />
+                                        {detailErrors.buyerName && <p className={styles.error}>{detailErrors.buyerName}</p>}
+                                    </div>
+
+                                    <div className={`${styles.fieldGroup} ${detailErrors.phone ? styles.fieldGroupError : ''}`}>
+                                        <label className={styles.label} htmlFor="modal-phone">Teléfono</label>
+                                        <input
+                                            id="modal-phone"
+                                            type="tel"
+                                            value={phone}
+                                            onChange={(e) => onPhoneChange(e.target.value)}
+                                            placeholder="Ej: 3584129488"
+                                            className={styles.input}
+                                        />
+                                        <p className={styles.hint}>Escribe el número sin 0 y sin 15</p>
+                                        {detailErrors.phone && <p className={styles.error}>{detailErrors.phone}</p>}
+                                    </div>
+                                </div>
+
+                                <div className={styles.actions}>
+                                    <button type="button" className={styles.cancelBtn} onClick={onBack}>Atrás</button>
+                                    <button type="submit" className={styles.primaryBtn}>Enviar comprobante</button>
+                                </div>
+                            </form>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default RegisterSaleModal;

--- a/src/components/wizard/RegisterSaleSheet.module.css
+++ b/src/components/wizard/RegisterSaleSheet.module.css
@@ -1,0 +1,336 @@
+/* RegisterSaleSheet.module.css — Mobile Bottom Sheet only */
+
+/* Overlay */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Panel */
+.panel {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 301;
+  max-height: 88vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--color-bg-secondary);
+  border-radius: 24px 24px 0 0;
+  box-shadow: 0 -12px 48px rgba(0, 0, 0, 0.5);
+  padding: var(--space-lg);
+  padding-bottom: max(var(--space-xl), env(safe-area-inset-bottom));
+  animation: slideUp 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+  box-sizing: border-box;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(100%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.handle {
+  width: 36px;
+  height: 4px;
+  margin: 0 auto var(--space-md);
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 2px;
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+
+.title {
+  flex: 1;
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  line-height: 1.3;
+  letter-spacing: -0.2px;
+}
+
+.closeBtn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: color var(--transition-base), background-color var(--transition-base);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.closeBtn:hover {
+  color: var(--color-text-primary);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+/* Event List */
+.eventList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+}
+
+.eventCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  width: 100%;
+  padding: var(--space-md);
+  background: var(--color-bg-tertiary);
+  border: 1.5px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  text-align: left;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.eventCard:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.eventCardSelected {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.eventCardContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.eventTitle {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  line-height: 1.3;
+}
+
+.eventStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-success);
+  background: rgba(52, 199, 89, 0.1);
+  padding: 3px 8px;
+  border-radius: var(--radius-full);
+  align-self: flex-start;
+}
+
+.statusDot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background-color: var(--color-success);
+}
+
+.checkIcon { color: var(--color-primary); }
+
+/* Form */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldError .input { border-color: var(--color-error); }
+
+.label {
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  letter-spacing: 0.1px;
+}
+
+.input {
+  width: 100%;
+  min-height: 48px;
+  padding: var(--space-md);
+  background: var(--color-bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  box-sizing: border-box;
+}
+
+.input::placeholder { color: var(--color-text-tertiary); }
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-light);
+}
+
+.error {
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+}
+
+.hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+
+/* Dish Selector */
+.dishSelector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-md);
+  background: var(--color-bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-xs);
+}
+
+.dishHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-xs);
+}
+
+.dishName {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.dishPrice {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
+}
+
+/* Wizard Navigation */
+.wizardNav {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.backBtn {
+  flex: 1;
+  min-height: 48px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--color-text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: var(--radius-xl);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: background-color var(--transition-base);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.backBtn:hover { background: rgba(255, 255, 255, 0.12); }
+.backBtn:active { transform: scale(0.98); }
+
+.submitBtn {
+  flex: 2;
+  width: 100%;
+  min-height: 48px;
+  margin-top: var(--space-sm);
+  background: var(--color-white);
+  color: var(--color-bg-primary);
+  border: none;
+  border-radius: var(--radius-xl);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  -webkit-tap-highlight-color: transparent;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* When used alone (not in wizard nav), reset flex */
+.field + .submitBtn,
+.error + .submitBtn {
+  flex: none;
+}
+
+.submitBtn:hover  {
+  background: var(--color-gray-900);
+  transform: translateY(-1px);
+}
+.submitBtn:active { transform: scale(0.98); }
+.submitBtn:disabled { opacity: 0.45; cursor: not-allowed; transform: none; }
+
+/* Success Screen */
+.successScreen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--space-lg) 0;
+  gap: var(--space-md);
+}
+
+.successIcon {
+  color: var(--color-success);
+  margin-bottom: var(--space-xs);
+}
+
+.successTitle {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+}
+
+.successDesc {
+  margin: 0;
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.successDesc strong {
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
+}
+
+/* Hidden on desktop */
+@media (min-width: 768px) {
+  .overlay,
+  .panel {
+    display: none !important;
+  }
+}

--- a/src/components/wizard/RegisterSaleSheet.tsx
+++ b/src/components/wizard/RegisterSaleSheet.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+/**
+ * RegisterSaleSheet (Mobile)
+ *
+ * Bottom-sheet presentation of the "Registrar Venta" wizard.
+ * Receives all state and callbacks from RegisterSaleWizard.
+ * Hidden on desktop via CSS.
+ */
+
+import React from 'react';
+import { Check, CheckCircle, X } from 'lucide-react';
+import type { SaleEvent } from './RegisterSaleWizard';
+import type { SaleDetailsErrors } from '@/utils/registerSaleSchema';
+import QuantityStepper from './QuantityStepper';
+import styles from './RegisterSaleSheet.module.css';
+
+interface Props {
+    step: 1 | 2;
+    isSuccess: boolean;
+    activeEvents: SaleEvent[];
+    currentEvent?: SaleEvent;
+    isFoodSale: boolean;
+    selectedEventId: string;
+    eventError?: string;
+    detailErrors: SaleDetailsErrors;
+    saleQuantity: number;
+    buyerName: string;
+    phone: string;
+    selectedDishes: Record<string, number>;
+    onClose: () => void;
+    onSelectEvent: (id: string) => void;
+    onContinue: () => void;
+    onBack: () => void;
+    onQuantityChange: (qty: number) => void;
+    onBuyerNameChange: (val: string) => void;
+    onPhoneChange: (val: string) => void;
+    onDishChange: (dishName: string, qty: number) => void;
+    onSubmit: (e: React.FormEvent) => void;
+}
+
+const RegisterSaleSheet: React.FC<Props> = ({
+    step,
+    isSuccess,
+    activeEvents,
+    currentEvent,
+    isFoodSale,
+    selectedEventId,
+    eventError,
+    detailErrors,
+    saleQuantity,
+    buyerName,
+    phone,
+    selectedDishes,
+    onClose,
+    onSelectEvent,
+    onContinue,
+    onBack,
+    onQuantityChange,
+    onBuyerNameChange,
+    onPhoneChange,
+    onDishChange,
+    onSubmit,
+}) => {
+    return (
+        <>
+            <div className={styles.overlay} onClick={onClose} aria-hidden="true" />
+            <div
+                className={styles.panel}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Registrar venta"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className={styles.handle} aria-hidden="true" />
+
+                {/* ── Success Screen ────────────────────────────────────────── */}
+                {isSuccess && (
+                    <div className={styles.successScreen}>
+                        <div className={styles.successIcon}>
+                            <CheckCircle size={48} strokeWidth={1.5} />
+                        </div>
+                        <h2 className={styles.successTitle}>¡Venta registrada!</h2>
+                        <p className={styles.successDesc}>
+                            La venta de <strong>{buyerName}</strong> fue registrada correctamente en{' '}
+                            <strong>{currentEvent?.name}</strong>.
+                        </p>
+                        <button type="button" className={styles.submitBtn} onClick={onClose}>
+                            Listo
+                        </button>
+                    </div>
+                )}
+
+                {/* ── Step 1: Event Selection ───────────────────────────────── */}
+                {!isSuccess && step === 1 && (
+                    <>
+                        <div className={styles.header}>
+                            <h2 className={styles.title}>Seleccionar evento</h2>
+                            <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Cerrar">
+                                <X size={24} />
+                            </button>
+                        </div>
+
+                        <div className={styles.eventList}>
+                            {activeEvents.map((event) => (
+                                <button
+                                    key={event.id}
+                                    type="button"
+                                    className={`${styles.eventCard} ${selectedEventId === event.id ? styles.eventCardSelected : ''}`}
+                                    onClick={() => onSelectEvent(event.id)}
+                                >
+                                    <div className={styles.eventCardContent}>
+                                        <div className={styles.eventStatus}>
+                                            <span className={styles.statusDot} />
+                                            <span>ACTIVO</span>
+                                        </div>
+                                        <div className={styles.eventTitle}>{event.name}</div>
+                                    </div>
+                                    {selectedEventId === event.id && <Check size={24} className={styles.checkIcon} />}
+                                </button>
+                            ))}
+                        </div>
+
+                        {eventError && <p className={styles.error}>{eventError}</p>}
+
+                        <button
+                            type="button"
+                            className={styles.submitBtn}
+                            onClick={onContinue}
+                            disabled={!selectedEventId}
+                        >
+                            Continuar
+                        </button>
+                    </>
+                )}
+
+                {/* ── Step 2: Sale Details ──────────────────────────────────── */}
+                {!isSuccess && step === 2 && (
+                    <>
+                        <div className={styles.header}>
+                            <h2 className={styles.title}>{currentEvent?.name}</h2>
+                            <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Cerrar">
+                                <X size={24} />
+                            </button>
+                        </div>
+
+                        <form onSubmit={onSubmit} className={styles.form} noValidate>
+                            {isFoodSale && currentEvent?.dishes ? (
+                                <div className={styles.field}>
+                                    <label className={styles.label}>Seleccionar platos</label>
+                                    {currentEvent.dishes.map((dish) => (
+                                        <div key={dish.name} className={styles.dishSelector}>
+                                            <div className={styles.dishHeader}>
+                                                <span className={styles.dishName}>{dish.name}</span>
+                                                <span className={styles.dishPrice}>${dish.price.toLocaleString()}</span>
+                                            </div>
+                                            <input
+                                                type="number"
+                                                min={0}
+                                                value={selectedDishes[dish.name] ?? 0}
+                                                onChange={(e) => onDishChange(dish.name, parseInt(e.target.value, 10) || 0)}
+                                                className={styles.input}
+                                                placeholder="Cantidad"
+                                            />
+                                        </div>
+                                    ))}
+                                    {detailErrors.dishes && <span className={styles.error}>{detailErrors.dishes}</span>}
+                                </div>
+                            ) : (
+                                <div className={styles.field}>
+                                    <label className={styles.label}>Cantidad de números</label>
+                                    <QuantityStepper
+                                        value={saleQuantity}
+                                        onChange={onQuantityChange}
+                                        min={1}
+                                    />
+                                </div>
+                            )}
+
+                            <div className={`${styles.field} ${detailErrors.buyerName ? styles.fieldError : ''}`}>
+                                <label className={styles.label} htmlFor="sheet-buyer">Nombre del comprador</label>
+                                <input
+                                    id="sheet-buyer"
+                                    type="text"
+                                    value={buyerName}
+                                    onChange={(e) => onBuyerNameChange(e.target.value)}
+                                    placeholder="Ej: María González"
+                                    className={styles.input}
+                                />
+                                {detailErrors.buyerName && <span className={styles.error}>{detailErrors.buyerName}</span>}
+                            </div>
+
+                            <div className={`${styles.field} ${detailErrors.phone ? styles.fieldError : ''}`}>
+                                <label className={styles.label} htmlFor="sheet-phone">Teléfono</label>
+                                <input
+                                    id="sheet-phone"
+                                    type="tel"
+                                    value={phone}
+                                    onChange={(e) => onPhoneChange(e.target.value)}
+                                    placeholder="Ej: 3584129488"
+                                    className={styles.input}
+                                />
+                                <span className={styles.hint}>Escribe el número sin 0 y sin 15</span>
+                                {detailErrors.phone && <span className={styles.error}>{detailErrors.phone}</span>}
+                            </div>
+
+                            <div className={styles.wizardNav}>
+                                <button type="button" className={styles.backBtn} onClick={onBack}>Atrás</button>
+                                <button type="submit" className={styles.submitBtn}>Enviar comprobante</button>
+                            </div>
+                        </form>
+                    </>
+                )}
+            </div>
+        </>
+    );
+};
+
+export default RegisterSaleSheet;

--- a/src/components/wizard/RegisterSaleWizard.tsx
+++ b/src/components/wizard/RegisterSaleWizard.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+/**
+ * RegisterSaleWizard
+ *
+ * Orchestrates the multi-step "Registrar Venta" flow.
+ * Owns all shared state and passes it down to the responsive
+ * presentational components: RegisterSaleSheet (mobile) and
+ * RegisterSaleModal (desktop).
+ */
+
+import React, { useState, useCallback } from 'react';
+import { validateEventStep, validateSaleDetails, SaleDetailsErrors } from '@/utils/registerSaleSchema';
+import RegisterSaleSheet from './RegisterSaleSheet';
+import RegisterSaleModal from './RegisterSaleModal';
+
+export interface Dish {
+    name: string;
+    price: number;
+    sold?: number;
+    total?: number;
+}
+
+export interface SaleEvent {
+    id: string;
+    name: string;
+    status: string;
+    type: string;
+    collected?: number;
+    goal?: number;
+    soldUnits?: number;
+    totalUnits?: number;
+    dishes?: Dish[];
+}
+
+interface RegisterSaleWizardProps {
+    isOpen: boolean;
+    onClose: () => void;
+    events: SaleEvent[];
+}
+
+const RegisterSaleWizard: React.FC<RegisterSaleWizardProps> = ({ isOpen, onClose, events }) => {
+    // ─── Wizard Step State ────────────────────────────────────────────────
+    const [mobileStep, setMobileStep] = useState<1 | 2>(1);
+    const [desktopStep, setDesktopStep] = useState<1 | 2>(1);
+    const [isSuccess, setIsSuccess] = useState(false);
+
+    // ─── Form State ───────────────────────────────────────────────────────
+    const [selectedEventId, setSelectedEventId] = useState('');
+    const [saleQuantity, setSaleQuantity] = useState(1);
+    const [buyerName, setBuyerName] = useState('');
+    const [phone, setPhone] = useState('');
+    const [selectedDishes, setSelectedDishes] = useState<Record<string, number>>({});
+
+    // ─── Error State ──────────────────────────────────────────────────────
+    const [eventError, setEventError] = useState<string | undefined>();
+    const [detailErrors, setDetailErrors] = useState<SaleDetailsErrors>({});
+
+    // ─── Derived State ────────────────────────────────────────────────────
+    const activeEvents = events.filter((e) => e.status === 'active');
+    const currentEvent = events.find((e) => e.id === selectedEventId);
+    const isFoodSale = currentEvent?.type === 'food_sale';
+
+    // ─── Handlers ─────────────────────────────────────────────────────────
+
+    const resetState = useCallback(() => {
+        setMobileStep(1);
+        setDesktopStep(1);
+        setSelectedEventId('');
+        setSaleQuantity(1);
+        setBuyerName('');
+        setPhone('');
+        setSelectedDishes({});
+        setEventError(undefined);
+        setDetailErrors({});
+        setIsSuccess(false);
+    }, []);
+
+    const handleClose = useCallback(() => {
+        resetState();
+        onClose();
+    }, [resetState, onClose]);
+
+    const handleSelectEvent = useCallback((id: string) => {
+        setSelectedEventId(id);
+        setEventError(undefined);
+    }, []);
+
+    const handleContinue = useCallback(() => {
+        const error = validateEventStep(selectedEventId);
+        if (error) {
+            setEventError(error);
+            return;
+        }
+        setMobileStep(2);
+        setDesktopStep(2);
+    }, [selectedEventId]);
+
+    const handleBack = useCallback(() => {
+        setMobileStep(1);
+        setDesktopStep(1);
+        setDetailErrors({});
+    }, []);
+
+    const handleDishChange = useCallback((dishName: string, quantity: number) => {
+        setSelectedDishes((prev) => ({ ...prev, [dishName]: quantity }));
+        if (detailErrors.dishes) {
+            setDetailErrors((prev) => ({ ...prev, dishes: undefined }));
+        }
+    }, [detailErrors.dishes]);
+
+    const handleSubmit = useCallback((e: React.FormEvent) => {
+        e.preventDefault();
+
+        const errors = validateSaleDetails(buyerName, phone, isFoodSale, selectedDishes);
+        if (Object.keys(errors).length > 0) {
+            setDetailErrors(errors);
+            return;
+        }
+
+        // TODO: Replace with API call — POST /api/sales
+        // Payload: { eventId: selectedEventId, buyerName, phone, quantity: saleQuantity, dishes: selectedDishes }
+        setIsSuccess(true);
+    }, [buyerName, phone, isFoodSale, selectedDishes]);
+
+    const clearDetailError = useCallback((field: keyof SaleDetailsErrors) => {
+        setDetailErrors((prev) => ({ ...prev, [field]: undefined }));
+    }, []);
+
+    if (!isOpen) return null;
+
+    const sharedProps = {
+        activeEvents,
+        currentEvent,
+        isFoodSale,
+        isSuccess,
+        // Step
+        selectedEventId,
+        eventError,
+        detailErrors,
+        // Form values
+        saleQuantity,
+        buyerName,
+        phone,
+        selectedDishes,
+        // Handlers
+        onClose: handleClose,
+        onSelectEvent: handleSelectEvent,
+        onContinue: handleContinue,
+        onBack: handleBack,
+        onQuantityChange: setSaleQuantity,
+        onBuyerNameChange: (val: string) => { setBuyerName(val); clearDetailError('buyerName'); },
+        onPhoneChange: (val: string) => { setPhone(val); clearDetailError('phone'); },
+        onDishChange: handleDishChange,
+        onSubmit: handleSubmit,
+    };
+
+    return (
+        <>
+            {/* Mobile: Bottom Sheet (hidden on desktop via CSS) */}
+            <RegisterSaleSheet {...sharedProps} step={mobileStep} />
+
+            {/* Desktop: Modal (hidden on mobile via CSS) */}
+            <RegisterSaleModal {...sharedProps} step={desktopStep} />
+        </>
+    );
+};
+
+export default RegisterSaleWizard;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,11 +2,29 @@
  * Application-wide constants
  */
 
+// ─── Snackbar Durations ─────────────────────────────────────────────────────
+
 export const SNACKBAR_DURATION = {
   SUCCESS: 3000,
   ERROR: 5000,
   CLOSE_ANIMATION: 300,
 } as const;
+
+// ─── Navigation Routes ──────────────────────────────────────────────────────
+
+export const ROUTES = {
+  HOME: '/',
+  CREATE_EVENT: '/create-event',
+  SELLERS_LIST: '/sellers-list',
+  BUYERS_LIST: '/buyers-list',
+  ADD_SELLER: '/add-seller',
+  EVENT_DETAIL: '/event-detail',
+  LOGIN: '/login',
+} as const;
+
+export type AppRoute = typeof ROUTES[keyof typeof ROUTES];
+
+// ─── Filter Options ─────────────────────────────────────────────────────────
 
 export const STATUS_OPTIONS = [
   { value: 'all', label: 'Todos los estados' },
@@ -15,14 +33,15 @@ export const STATUS_OPTIONS = [
 ] as const;
 
 export const EVENT_FILTER_OPTIONS = [
-  { value: 'all', label: 'TODOS' },
   { value: 'active', label: 'ACTIVOS' },
   { value: 'completed', label: 'FINALIZADOS' },
   { value: 'cancelled', label: 'CANCELADOS' },
+  { value: 'all', label: 'TODOS' },
 ] as const;
+
+// ─── Validation ─────────────────────────────────────────────────────────────
 
 export const VALIDATION_RULES = {
   PHONE_MIN_LENGTH: 8,
   NAME_MIN_LENGTH: 2,
 } as const;
-

--- a/src/hooks/useSnackbar.ts
+++ b/src/hooks/useSnackbar.ts
@@ -1,8 +1,11 @@
 /**
- * Custom hook for managing snackbar notifications
+ * Custom hook for managing snackbar notifications.
+ *
+ * Cleanup: All setTimeout references are stored and cleared
+ * on re-call and on component unmount to prevent memory leaks.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { SNACKBAR_DURATION } from '@/constants';
 
 interface UseSnackbarReturn {
@@ -16,30 +19,53 @@ export const useSnackbar = (duration: number = SNACKBAR_DURATION.SUCCESS): UseSn
   const [isVisible, setIsVisible] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
+  const animationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimers = useCallback(() => {
+    if (animationTimerRef.current) {
+      clearTimeout(animationTimerRef.current);
+      animationTimerRef.current = null;
+    }
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  // Clean up all timers when the component using this hook unmounts.
+  useEffect(() => {
+    return () => {
+      clearTimers();
+    };
+  }, [clearTimers]);
+
   const showSnackbar = useCallback(() => {
+    clearTimers();
+
     setIsVisible(true);
     setIsClosing(false);
 
     const closeAnimationDelay = duration - SNACKBAR_DURATION.CLOSE_ANIMATION;
-    
-    setTimeout(() => {
+
+    animationTimerRef.current = setTimeout(() => {
       setIsClosing(true);
     }, closeAnimationDelay);
 
-    setTimeout(() => {
+    hideTimerRef.current = setTimeout(() => {
       setIsVisible(false);
       setIsClosing(false);
     }, duration);
-  }, [duration]);
+  }, [duration, clearTimers]);
 
   const hideSnackbar = useCallback(() => {
+    clearTimers();
     setIsClosing(true);
-    setTimeout(() => {
+    hideTimerRef.current = setTimeout(() => {
       setIsVisible(false);
       setIsClosing(false);
     }, SNACKBAR_DURATION.CLOSE_ANIMATION);
-  }, []);
+  }, [clearTimers]);
 
   return { isVisible, isClosing, showSnackbar, hideSnackbar };
 };
-

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -4,6 +4,8 @@
  */
 
 import { Seller, Event, Buyer } from '@/types/models';
+import type { SaleEvent } from '@/components/wizard/RegisterSaleWizard';
+
 
 export const MOCK_SELLERS: Seller[] = [
   {
@@ -121,12 +123,12 @@ export const MOCK_EVENTS: Event[] = [
 
 // Generar compradores mock
 const generateBuyers = (): Buyer[] => {
-  const firstNames = ['Juan', 'María', 'Carlos', 'Ana', 'Luis', 'Laura', 'Pedro', 'Sofía', 'Diego', 'Carmen', 
+  const firstNames = ['Juan', 'María', 'Carlos', 'Ana', 'Luis', 'Laura', 'Pedro', 'Sofía', 'Diego', 'Carmen',
     'Roberto', 'Elena', 'Miguel', 'Patricia', 'José', 'Isabel', 'Francisco', 'Rosa', 'Antonio', 'Teresa',
     'Manuel', 'Raquel', 'Javier', 'Beatriz', 'Fernando', 'Lucía', 'Alejandro', 'Marta', 'Ricardo', 'Julia',
     'Sergio', 'Cristina', 'Pablo', 'Silvia', 'Andrés', 'Gloria', 'Daniel', 'Pilar', 'Gabriel', 'Mercedes',
     'Óscar', 'Dolores', 'Rafael', 'Amparo', 'Jorge', 'Montserrat', 'Rubén', 'Concepción', 'Álvaro', 'Josefa'];
-  
+
   const lastNames = ['Pérez', 'García', 'Rodríguez', 'López', 'Martínez', 'Sánchez', 'González', 'Fernández',
     'Díaz', 'Torres', 'Ramírez', 'Flores', 'Rivera', 'Gómez', 'Morales', 'Jiménez', 'Herrera', 'Ruiz',
     'Álvarez', 'Castillo', 'Romero', 'Vázquez', 'Núñez', 'Mendoza', 'Cruz', 'Ortiz', 'Gutiérrez', 'Chávez',
@@ -151,7 +153,7 @@ const generateBuyers = (): Buyer[] => {
     const lastName = lastNames[Math.floor(Math.random() * lastNames.length)];
     const phone = `3584${String(100000 + buyerId).padStart(6, '0')}`;
     const isActive = Math.random() > 0.1; // 90% activos
-    
+
     const seller = pickSellerForEvent('1');
     buyers.push({
       id: String(buyerId),
@@ -176,7 +178,7 @@ const generateBuyers = (): Buyer[] => {
     const lastName = lastNames[Math.floor(Math.random() * lastNames.length)];
     const phone = `3584${String(100000 + buyerId).padStart(6, '0')}`;
     const isActive = Math.random() > 0.1; // 90% activos
-    
+
     const seller = pickSellerForEvent('2');
     buyers.push({
       id: String(buyerId),
@@ -199,4 +201,33 @@ const generateBuyers = (): Buyer[] => {
 };
 
 export const MOCK_BUYERS: Buyer[] = generateBuyers();
+
+// ─── Home Page Events (extended with UI-specific data) ──────────────────────
+// TODO: Replace with API call. This shape combines Event data with UI props.
+
+export const MOCK_HOME_EVENTS: SaleEvent[] = [
+  {
+    id: '1',
+    status: 'active',
+    type: 'raffle',
+    name: 'Rifa día del niño del Grupo Scout General Deheza',
+    collected: 640000,
+    goal: 800000,
+    soldUnits: 640,
+    totalUnits: 800,
+  },
+  {
+    id: '2',
+    status: 'active',
+    type: 'food_sale',
+    name: 'Venta de comida - Platos especiales',
+    dishes: [
+      { name: 'Milanesa con papas', price: 2500, sold: 45, total: 100 },
+      { name: 'Empanadas (docena)', price: 3000, sold: 30, total: 80 },
+    ],
+  },
+  { id: '3', status: 'cancelled', type: 'raffle', name: 'Rifa cancelada', collected: 80000, goal: 300000, soldUnits: 80, totalUnits: 300 },
+  { id: '4', status: 'completed', type: 'raffle', name: 'Rifa completada', collected: 600000, goal: 600000, soldUnits: 600, totalUnits: 600 },
+  { id: '5', status: 'completed', type: 'raffle', name: 'Rifa completada 2', collected: 150000, goal: 200000, soldUnits: 150, totalUnits: 200 },
+];
 

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -399,26 +399,23 @@
   outline-offset: 2px;
 }
 
-/* Tertiary Button - Botón terciario (outline azul) */
+/* Tertiary Button - Botón terciario (outline blanco) */
 .btn-tertiary {
   background-color: transparent;
-  color: #007AFF;
-  border: 2px solid #007AFF;
+  color: var(--color-white);
+  border: 1px solid var(--color-white);
 }
 
 .btn-tertiary:hover:not(:disabled) {
-  background-color: #007AFF;
-  color: white;
+  background-color: rgba(255, 255, 255, 0.08);
 }
 
 .btn-tertiary:active:not(:disabled) {
-  background-color: #0056CC;
-  border-color: #0056CC;
-  color: white;
+  background-color: rgba(255, 255, 255, 0.12);
 }
 
 .btn-tertiary:focus-visible {
-  outline: 2px solid #007AFF;
+  outline: 2px solid var(--color-white);
   outline-offset: 2px;
 }
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -2,6 +2,41 @@
  * Core data models for the application
  */
 
+// ─── Const Objects (Single Source of Truth) ────────────────────────────────
+
+export const SELLER_STATUS = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+} as const;
+
+export const BUYER_STATUS = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+} as const;
+
+export const EVENT_TYPE = {
+  RAFFLE: 'raffle',
+  FOOD_SALE: 'food_sale',
+} as const;
+
+export const EVENT_STATUS = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+} as const;
+
+// ─── Derived Types ──────────────────────────────────────────────────────────
+
+export type SellerStatus = typeof SELLER_STATUS[keyof typeof SELLER_STATUS];
+export type BuyerStatus = typeof BUYER_STATUS[keyof typeof BUYER_STATUS];
+export type EventType = typeof EVENT_TYPE[keyof typeof EVENT_TYPE];
+export type EventStatus = typeof EVENT_STATUS[keyof typeof EVENT_STATUS];
+export type StatusFilter = 'all' | SellerStatus;
+export type EventStatusFilter = 'all' | EventStatus;
+
+// ─── Interfaces ─────────────────────────────────────────────────────────────
+
 export interface Seller {
   id: string;
   firstName: string;
@@ -40,11 +75,3 @@ export interface Event {
   totalNumbers: number;
   soldNumbers: number;
 }
-
-export type SellerStatus = 'active' | 'inactive';
-export type BuyerStatus = 'active' | 'inactive';
-export type EventType = 'raffle' | 'food_sale';
-export type EventStatus = 'active' | 'inactive' | 'completed';
-export type StatusFilter = 'all' | 'active' | 'inactive';
-export type EventStatusFilter = 'all' | 'active' | 'completed' | 'cancelled';
-

--- a/src/utils/registerSaleSchema.ts
+++ b/src/utils/registerSaleSchema.ts
@@ -1,0 +1,68 @@
+/**
+ * Zod validation schema for the "Registrar Venta" wizard.
+ * Single source of truth for all form validation rules —
+ * shared by both the mobile sheet and desktop modal.
+ */
+
+import { z } from 'zod';
+import { VALIDATION_RULES } from '@/constants';
+
+export const registerSaleSchema = z.object({
+    eventId: z.string().min(1, 'Debes seleccionar un evento'),
+    buyerName: z
+        .string()
+        .min(1, 'Este campo es requerido')
+        .min(VALIDATION_RULES.NAME_MIN_LENGTH, `Debe tener al menos ${VALIDATION_RULES.NAME_MIN_LENGTH} caracteres`),
+    phone: z
+        .string()
+        .min(1, 'Este campo es requerido')
+        .refine(
+            (val) => val.replace(/\D/g, '').length >= VALIDATION_RULES.PHONE_MIN_LENGTH,
+            { message: `Debe tener al menos ${VALIDATION_RULES.PHONE_MIN_LENGTH} dígitos` }
+        ),
+    quantity: z.number().int().min(1, 'La cantidad debe ser al menos 1'),
+    dishes: z.record(z.string(), z.number().int().min(0)).optional(),
+});
+
+export type RegisterSaleFormData = z.infer<typeof registerSaleSchema>;
+
+/** Validates only the event selection step (Step 1). */
+export const validateEventStep = (eventId: string): string | undefined => {
+    const result = registerSaleSchema.shape.eventId.safeParse(eventId);
+    return result.success ? undefined : result.error.issues[0].message;
+};
+
+/** Validates the sale details step (Step 2), given the event type. */
+export interface SaleDetailsErrors {
+    buyerName?: string;
+    phone?: string;
+    dishes?: string;
+}
+
+export const validateSaleDetails = (
+    buyerName: string,
+    phone: string,
+    isFoodSale: boolean,
+    dishes: Record<string, number>
+): SaleDetailsErrors => {
+    const errors: SaleDetailsErrors = {};
+
+    const nameResult = registerSaleSchema.shape.buyerName.safeParse(buyerName);
+    if (!nameResult.success) {
+        errors.buyerName = nameResult.error.issues[0].message;
+    }
+
+    const phoneResult = registerSaleSchema.shape.phone.safeParse(phone);
+    if (!phoneResult.success) {
+        errors.phone = phoneResult.error.issues[0].message;
+    }
+
+    if (isFoodSale) {
+        const totalDishes = Object.values(dishes).reduce((sum, qty) => sum + qty, 0);
+        if (totalDishes === 0) {
+            errors.dishes = 'Debes seleccionar al menos un plato';
+        }
+    }
+
+    return errors;
+};


### PR DESCRIPTION
## Resumen

- **Wizard Registrar Venta**: flujo de 2 pasos (selección de evento → datos de comprador/cantidad). Bottom-sheet en mobile, modal en desktop. Validación con Zod y pantalla de éxito al finalizar.
- **QuantityStepper**: nuevo componente reutilizable de +/− con soporte de long-press, teclado y entrada manual.
- **Rediseño Event Detail**: se eliminó la card de progreso. La info del evento se muestra como header abierto con H1, barra de progreso delgada y fila de stats (Recaudado / Objetivo / Números) sin contenedor visible.
- **Mejoras UI dark mode**: unificación de estilos en cards de eventos, sidebar con transiciones de logos, dropdowns personalizados y correcciones generales de consistencia visual.

## Plan de testing

- [ ] Abrir "Registrar venta" en mobile → verificar bottom-sheet de 2 pasos
- [ ] Abrir "Registrar venta" en desktop → verificar modal de 2 pasos
- [ ] Seleccionar evento de tipo raffle → aparece QuantityStepper
- [ ] Seleccionar evento de tipo food_sale → aparece selector de platos
- [ ] Completar formulario → ver pantalla de éxito → cerrar
- [ ] Validar errores: continuar sin seleccionar evento, enviar sin nombre/teléfono
- [ ] Navegar a Event Detail → verificar H1 visible, barra de progreso y stats
- [ ] Verificar en mobile que el nombre del evento se muestra correctamente
- [ ] Verificar build: `npm run build` sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)