### PR TITLE
feat: mejoras UI en compradores, vendedores, métricas y wizard

### DIFF
--- a/src/app/event-detail/EventDetail.module.css
+++ b/src/app/event-detail/EventDetail.module.css
@@ -416,6 +416,14 @@
   border-bottom: none;
 }
 
+.salesItemClickable {
+  cursor: pointer;
+  transition: background-color var(--transition-base);
+}
+.salesItemClickable:hover {
+  background: var(--color-bg-tertiary);
+}
+
 /* Checkbox wrapper for mobile list */
 .salesList .checkboxWrapper {
   display: flex;
@@ -451,7 +459,7 @@
 
 .sellerName {
   font-size: var(--font-size-base);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
 }
 
@@ -698,7 +706,6 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
-  padding-right: 120px; /* room for badge */
 }
 
 .metricProgressHeader {
@@ -721,7 +728,7 @@
 
 .metricTrack {
   height: 6px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.12);
   border-radius: var(--radius-full);
   overflow: hidden;
 }
@@ -737,8 +744,6 @@
 .metricKpis {
   display: flex;
   gap: 0;
-  border-top: 1px solid var(--color-border-divider);
-  padding-top: var(--space-md);
 }
 
 .metricKpi {
@@ -776,8 +781,8 @@
 
 /* Dish breakdown — food_sale */
 .dishBreakdown {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: var(--space-sm);
   border-top: 1px solid var(--color-border-divider);
   padding-top: var(--space-md);
@@ -790,6 +795,7 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin: 0 0 var(--space-xs);
+  grid-column: 1 / -1;
 }
 
 .dishRow {
@@ -811,7 +817,7 @@
 .dishTrack {
   width: 80px;
   height: 4px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.12);
   border-radius: var(--radius-full);
   overflow: hidden;
   flex-shrink: 0;
@@ -844,6 +850,17 @@
   }
   .dishTrack {
     width: 120px;
+  }
+  .dishBreakdown {
+    grid-template-columns: 1fr 1fr;
+    column-gap: 0;
+  }
+  .dishBreakdown .dishRow:nth-child(even) {
+    border-right: 1px solid var(--color-border-divider);
+    padding-right: var(--space-lg);
+  }
+  .dishBreakdown .dishRow:nth-child(odd):not(:first-child) {
+    padding-left: var(--space-lg);
   }
 }
 
@@ -1142,6 +1159,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
+  padding: var(--space-lg);
 }
 
 .configSectionTitle {
@@ -1156,13 +1174,14 @@
 .configActions {
   display: flex;
   gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg) var(--space-lg);
+  border-top: 1px solid var(--color-border-light);
 }
 
 /* Danger Zone */
 .dangerZone {
   background: rgba(255, 59, 48, 0.05);
-  border: 1px solid rgba(255, 59, 48, 0.15);
-  border-radius: var(--radius-lg);
+  border-radius: inherit;
   padding: var(--space-lg);
   display: flex;
   flex-direction: row;
@@ -1466,14 +1485,13 @@
     display: flex;
     flex-direction: column;
     gap: 0;
-    padding: 0 var(--space-md);
   }
 
   .tableView .salesItem {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: var(--space-md) 0;
+    padding: var(--space-md);
     border-bottom: 1px solid var(--color-border-light);
     gap: var(--space-md);
   }

--- a/src/app/event-detail/page.tsx
+++ b/src/app/event-detail/page.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useMemo, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import styles from './EventDetail.module.css';
-import AssignNumbersModal from './AssignNumbersModal';
 import BottomSheet from '@/components/BottomSheet';
 import { MOCK_BUYERS, MOCK_EVENTS, MOCK_SELLERS, MOCK_HOME_EVENTS } from '@/mocks/data';
 import { Buyer } from '@/types/models';
@@ -11,7 +10,6 @@ import { SNACKBAR_DURATION } from '@/constants';
 import { useSnackbar } from '@/hooks/useSnackbar';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import MobileListRow from '@/components/MobileListRow';
-import MobileStickyActionBar from '@/components/MobileStickyActionBar';
 import EmptyState from '@/components/EmptyState';
 import TabBar from '@/components/TabBar';
 import RegisterSaleWizard from '@/components/wizard/RegisterSaleWizard';
@@ -64,6 +62,34 @@ function getDaysRemaining(endDate: string): number {
   return Math.ceil((end.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
 }
 
+// ─── Circular Progress Ring ───────────────────────────────────────────────────
+function CircularProgress({ percentage }: { percentage: number }) {
+  const radius = 54;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference - (percentage / 100) * circumference;
+  return (
+    <svg width="140" height="140" viewBox="0 0 140 140" className={styles.progressRing}>
+      <circle cx="70" cy="70" r={radius} fill="none" stroke="rgba(255,255,255,0.07)" strokeWidth="10" />
+      <circle
+        cx="70" cy="70" r={radius} fill="none"
+        stroke="#5AC8FA" strokeWidth="10"
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={strokeDashoffset}
+        transform="rotate(-90 70 70)"
+        style={{ transition: 'stroke-dashoffset 0.6s ease' }}
+      />
+      <text x="70" y="65" textAnchor="middle" dominantBaseline="middle"
+        fill="white" fontSize="22" fontWeight="700" fontFamily="inherit">
+        {percentage}%
+      </text>
+      <text x="70" y="83" textAnchor="middle" dominantBaseline="middle"
+        fill="rgba(255,255,255,0.5)" fontSize="11" fontFamily="inherit">
+        vendido
+      </text>
+    </svg>
+  );
+}
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 export default function EventDetail() {
@@ -105,9 +131,7 @@ function EventDetailContent() {
   // Vendors tab state
   const [activeVendorTab, setActiveVendorTab] = useState<VendorTab>('collected');
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedVendors, setSelectedVendors] = useState<number[]>([]);
-  const [selectedCollectedVendors, setSelectedCollectedVendors] = useState<number[]>([]);
-  const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
+  const [vendorDetailItem, setVendorDetailItem] = useState<(typeof INITIAL_COLLECTED)[0] | null>(null);
   const [collectedData, setCollectedData] = useState(INITIAL_COLLECTED);
   const [pendingData, setPendingData] = useState(INITIAL_PENDING);
 
@@ -136,9 +160,7 @@ function EventDetailContent() {
   const [buyers, setBuyers] = useState<Buyer[]>(MOCK_BUYERS);
   const [buyerSearchTerm, setBuyerSearchTerm] = useState('');
   const [activeBuyerTab, setActiveBuyerTab] = useState<BuyerTab>('tab1');
-  const [selectedBuyers, setSelectedBuyers] = useState<string[]>([]);
   const [buyerMobileMenuOpen, setBuyerMobileMenuOpen] = useState<string | null>(null);
-  const [buyerDesktopMenuOpen, setBuyerDesktopMenuOpen] = useState<string | null>(null);
   const [purchaseDetailBuyer, setPurchaseDetailBuyer] = useState<Buyer | null>(null);
   const [raffleDetailBuyer, setRaffleDetailBuyer] = useState<Buyer | null>(null);
 
@@ -190,21 +212,6 @@ function EventDetailContent() {
     });
   }, [eventBuyers, buyerSearchTerm, activeBuyerTab, eventType]);
 
-  const selectionType = useMemo(() => {
-    if (selectedBuyers.length === 0) return null;
-    return eventType;
-  }, [selectedBuyers, eventType]);
-
-  const areAllSelectedDelivered = useMemo(
-    () => selectedBuyers.length > 0 && selectedBuyers.every(id => buyers.find(b => b.id === id)?.isDelivered),
-    [selectedBuyers, buyers]
-  );
-
-  const areAllSelectedPrinted = useMemo(
-    () => selectedBuyers.length > 0 && selectedBuyers.every(id => buyers.find(b => b.id === id)?.isPrinted),
-    [selectedBuyers, buyers]
-  );
-
   // ── Business rules ────────────────────────────────────────────────────────
   const prizesLocked = eventType === 'raffle' && eventData.soldNumbers > 0;
 
@@ -225,10 +232,7 @@ function EventDetailContent() {
 
   // ── Status ───────────────────────────────────────────────────────────────
   const statusLabel =
-    daysRemaining <= 0 ? 'FINALIZADO' :
-    daysRemaining === 1 ? 'ACTIVO — Finaliza mañana' :
-    daysRemaining <= 5 ? `ACTIVO — ${daysRemaining} días restantes` :
-    `ACTIVO — ${daysRemaining} días restantes`;
+    daysRemaining <= 0 ? 'FINALIZADO' : 'ACTIVO';
 
   const statusBadgeClass =
     daysRemaining <= 0 ? styles.statusBadgeCompleted :
@@ -236,55 +240,34 @@ function EventDetailContent() {
     styles.statusBadgeActive;
 
   // ── Vendor actions ───────────────────────────────────────────────────────
-  const handleMarkAsPaid = () => {
-    if (!selectedVendors.length) return;
-    const toMove = pendingData.filter(v => selectedVendors.includes(v.id));
-    setCollectedData(p => [...p, ...toMove]);
-    setPendingData(p => p.filter(v => !selectedVendors.includes(v.id)));
-    setSelectedVendors([]);
-  };
-
-  const handleAssignMoreNumbers = () => {
-    if (selectedCollectedVendors.length > 0) setIsAssignModalOpen(true);
-  };
-
-  const handleModalConfirm = (data: { quantity: number; autoAssign: boolean; fromNumber: string; toNumber: string }) => {
-    const toMove = collectedData.filter(v => selectedCollectedVendors.includes(v.id));
-    const updated = toMove.map(v => ({
-      ...v, total: v.total + data.quantity, sold: 0, amount: 0, percentage: 0,
-    }));
-    setCollectedData(p => p.filter(v => !selectedCollectedVendors.includes(v.id)));
-    setPendingData(p => [...p, ...updated]);
-    setIsAssignModalOpen(false);
-    setSelectedCollectedVendors([]);
-    setActiveVendorTab('pending');
-  };
-
-  const toggleVendorSelect = (id: number, tab: VendorTab) => {
-    if (tab === 'pending') {
-      setSelectedVendors(p => p.includes(id) ? p.filter(x => x !== id) : [...p, id]);
+  const handleToggleVendorCobrado = (item: (typeof INITIAL_COLLECTED)[0]) => {
+    const isCollected = collectedData.some(v => v.id === item.id);
+    if (isCollected) {
+      setCollectedData(p => p.filter(v => v.id !== item.id));
+      setPendingData(p => [...p, item]);
     } else {
-      setSelectedCollectedVendors(p => p.includes(id) ? p.filter(x => x !== id) : [...p, id]);
+      setPendingData(p => p.filter(v => v.id !== item.id));
+      setCollectedData(p => [...p, item]);
     }
+    setVendorDetailItem(null);
+    vendorSnackbar.showSnackbar();
   };
 
   // ── Buyer hooks & side effects ────────────────────────────────────────────
   const isDesktop = useMediaQuery('(min-width: 768px)');
   const deliverySnackbar = useSnackbar(SNACKBAR_DURATION.SUCCESS);
   const raffleSnackbar = useSnackbar(SNACKBAR_DURATION.SUCCESS);
+  const vendorSnackbar = useSnackbar(SNACKBAR_DURATION.SUCCESS);
 
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (buyerMobileMenuOpen && !(event.target as Element).closest(`.${listStyles.mobileMenuContainer}`)) {
         setBuyerMobileMenuOpen(null);
       }
-      if (buyerDesktopMenuOpen && !(event.target as Element).closest(`.${listStyles.desktopMenuContainer}`)) {
-        setBuyerDesktopMenuOpen(null);
-      }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [buyerMobileMenuOpen, buyerDesktopMenuOpen]);
+  }, [buyerMobileMenuOpen]);
 
   // ── Buyer handlers ────────────────────────────────────────────────────────
   const handleToggleBuyerStatus = (buyerId: string) => {
@@ -293,35 +276,10 @@ function EventDetailContent() {
     ));
   };
 
-  const handleSelectBuyer = (buyerId: string) => {
-    setSelectedBuyers(prev =>
-      prev.includes(buyerId) ? prev.filter(id => id !== buyerId) : [...prev, buyerId]
-    );
-  };
-
-  const handleSelectAllBuyers = () => {
-    const selectable = filteredBuyers.filter(b => b.status === 'active');
-    if (selectedBuyers.length === selectable.length && selectable.length > 0) {
-      setSelectedBuyers([]);
-    } else {
-      setSelectedBuyers(selectable.map(b => b.id));
-    }
-  };
-
-  const handlePrintReceipts = (printed: boolean) => {
-    setBuyers(prev => prev.map(b =>
-      selectedBuyers.includes(b.id) ? { ...b, isPrinted: printed } : b
-    ));
-    setSelectedBuyers([]);
+  const handlePrintAllVisible = () => {
+    const ids = new Set(filteredBuyers.map(b => b.id));
+    setBuyers(prev => prev.map(b => ids.has(b.id) ? { ...b, isPrinted: true } : b));
     raffleSnackbar.showSnackbar();
-  };
-
-  const handleSetDeliveredStatus = (status: boolean) => {
-    setBuyers(prev => prev.map(b =>
-      selectedBuyers.includes(b.id) ? { ...b, isDelivered: status } : b
-    ));
-    setSelectedBuyers([]);
-    deliverySnackbar.showSnackbar();
   };
 
   // SVG icons for buyer context menus
@@ -333,18 +291,19 @@ function EventDetailContent() {
     </svg>
   );
   const IconDisable = () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-      <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+      <path d="M5.636 5.636L18.364 18.364" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
     </svg>
   );
   const IconEnable = () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
       <path d="M9 12L11 14L15 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
       <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
   const IconDetail = () => (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
       <path d="M14 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V8L14 2Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
       <path d="M14 2V8H20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
       <path d="M16 13H8M16 17H8M10 9H8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
@@ -496,30 +455,17 @@ function EventDetailContent() {
                     onChange={e => setSearchQuery(e.target.value)}
                   />
                 </div>
-                {activeVendorTab === 'pending' && selectedVendors.length > 0 && (
-                  <button className={styles.markAsPaidButton} onClick={handleMarkAsPaid}>Cobrado</button>
-                )}
-                {activeVendorTab === 'collected' && selectedCollectedVendors.length > 0 && (
-                  <button className={styles.markAsPaidButton} onClick={handleAssignMoreNumbers}>Asignar más números</button>
-                )}
               </div>
 
               {/* Desktop table view */}
               <div className={styles.tableView}>
                 {filteredVendorData.map((item, index) => {
-                  const isSelected = activeVendorTab === 'pending'
-                    ? selectedVendors.includes(item.id)
-                    : selectedCollectedVendors.includes(item.id);
                   return (
-                    <div key={item.id ?? index} className={`${styles.salesItem} ${styles.tableRow}`}>
-                      <div className={styles.checkboxWrapper}>
-                        <input
-                          type="checkbox"
-                          checked={isSelected}
-                          onChange={() => toggleVendorSelect(item.id, activeVendorTab)}
-                          className={styles.checkbox}
-                        />
-                      </div>
+                    <div
+                      key={item.id ?? index}
+                      className={`${styles.salesItem} ${listStyles.tableRow} ${styles.salesItemClickable}`}
+                      onClick={() => setVendorDetailItem(item)}
+                    >
                       <div className={styles.salesItemLeft}>
                         <div className={styles.sellerName}>{item.name}</div>
                         <div className={styles.sellerStats}>{item.sold} de {item.total} vendidos</div>
@@ -536,20 +482,12 @@ function EventDetailContent() {
               {/* Mobile list view */}
               <div className={styles.salesList}>
                 {filteredVendorData.map((item, index) => {
-                  const isSelected = activeVendorTab === 'pending'
-                    ? selectedVendors.includes(item.id)
-                    : selectedCollectedVendors.includes(item.id);
                   return (
-                    <div key={item.id ?? index} className={styles.salesItem}>
-                      <div className={styles.checkboxWrapper}>
-                        <input
-                          type="checkbox"
-                          checked={isSelected}
-                          onChange={() => toggleVendorSelect(item.id, activeVendorTab)}
-                          className={styles.checkbox}
-                          aria-label={`Seleccionar ${item.name}`}
-                        />
-                      </div>
+                    <div
+                      key={item.id ?? index}
+                      className={`${styles.salesItem} ${styles.salesItemClickable}`}
+                      onClick={() => setVendorDetailItem(item)}
+                    >
                       <div className={styles.salesItemLeft}>
                         <div className={styles.sellerName}>{item.name}</div>
                         <div className={styles.sellerStats}>{item.sold} de {item.total} vendidos</div>
@@ -619,46 +557,15 @@ function EventDetailContent() {
                     className={styles.searchInput}
                   />
                 </div>
-                {isDesktop && selectedBuyers.length > 0 && selectionType === 'raffle' && (
-                  <button onClick={() => handlePrintReceipts(!areAllSelectedPrinted)} className={styles.markAsPaidButton}>
-                    {areAllSelectedPrinted ? 'Desmarcar impreso' : 'Imprimir comprobantes'} ({selectedBuyers.length})
-                  </button>
-                )}
-                {isDesktop && selectedBuyers.length > 0 && selectionType === 'food_sale' && (
-                  <button onClick={() => handleSetDeliveredStatus(!areAllSelectedDelivered)} className={styles.markAsPaidButton}>
-                    {areAllSelectedDelivered ? 'Desmarcar' : 'Entregado'} ({selectedBuyers.length})
+                {eventType === 'raffle' && activeBuyerTab === 'tab2' && (
+                  <button onClick={handlePrintAllVisible} className={styles.markAsPaidButton}>
+                    Imprimir comprobante ({filteredBuyers.length})
                   </button>
                 )}
               </div>
 
               {/* Desktop table */}
-              {isDesktop && <table className={listStyles.table}>
-                  <thead>
-                    <tr>
-                      <th className={listStyles.checkboxColumn}>
-                        <div className={listStyles.checkboxWrapper}>
-                          <input
-                            type="checkbox"
-                            checked={
-                              filteredBuyers.filter(b => b.status === 'active').length > 0 &&
-                              selectedBuyers.length === filteredBuyers.filter(b => b.status === 'active').length
-                            }
-                            onChange={handleSelectAllBuyers}
-                            className={listStyles.checkbox}
-                            aria-label="Seleccionar todos"
-                          />
-                        </div>
-                      </th>
-                      <th>
-                        <div className={listStyles.headerWithCounter}>
-                          <span>Comprador</span>
-                          <span className={listStyles.headerCounter}>{filteredBuyers.length}</span>
-                        </div>
-                      </th>
-                      <th>Vendedor</th>
-                      <th className={listStyles.actionsColumn}></th>
-                    </tr>
-                  </thead>
+              {isDesktop && <table className={listStyles.table} style={{ tableLayout: 'auto' }}>
                   <tbody>
                     {filteredBuyers.map(buyer => {
                       const seller = MOCK_SELLERS.find(s => s.id === buyer.sellerId);
@@ -666,69 +573,30 @@ function EventDetailContent() {
                         <tr
                           key={buyer.id}
                           className={`${listStyles.tableRow} ${buyer.status === 'inactive' ? listStyles.tableRowInactive : ''}`}
+                          onClick={() => eventType === 'raffle' ? setRaffleDetailBuyer(buyer) : setPurchaseDetailBuyer(buyer)}
+                          style={{ cursor: 'pointer' }}
                         >
-                          <td className={listStyles.checkboxColumn}>
-                            <div className={listStyles.checkboxWrapper}>
-                              <input
-                                type="checkbox"
-                                checked={selectedBuyers.includes(buyer.id)}
-                                onChange={() => handleSelectBuyer(buyer.id)}
-                                className={listStyles.checkbox}
-                                disabled={buyer.status === 'inactive'}
-                                aria-label={`Seleccionar ${buyer.firstName} ${buyer.lastName}`}
-                              />
-                            </div>
-                          </td>
                           <td>
                             <div className={buyerStyles.buyerInfo}>
-                              <div
-                                className={buyerStyles.buyerName}
-                                onClick={() => eventType === 'raffle' ? setRaffleDetailBuyer(buyer) : setPurchaseDetailBuyer(buyer)}
-                                style={{ cursor: 'pointer' }}
-                              >
+                              <div className={buyerStyles.buyerName}>
                                 {buyer.firstName} {buyer.lastName}
                               </div>
                               <div className={buyerStyles.buyerPhone}>{buyer.phone}</div>
+                              {seller && (
+                                <div className={buyerStyles.buyerPhone}>Vendedor: {seller.firstName} {seller.lastName}</div>
+                              )}
                             </div>
                           </td>
-                          <td>
-                            {seller ? (
-                              <div className={listStyles.cellTruncate}>{seller.firstName} {seller.lastName}</div>
-                            ) : (
-                              <div className={listStyles.noEvent}>—</div>
-                            )}
-                          </td>
-                          <td className={listStyles.actionsColumn}>
-                            <div className={listStyles.desktopMenuContainer}>
+                          <td className={listStyles.inlineActionsCell}>
+                            <div>
                               <button
+                                type="button"
                                 className={listStyles.desktopMenuButton}
-                                onClick={() => setBuyerDesktopMenuOpen(buyerDesktopMenuOpen === buyer.id ? null : buyer.id)}
-                                aria-label="Menú de opciones"
-                                aria-expanded={buyerDesktopMenuOpen === buyer.id}
-                                aria-haspopup="true"
+                                aria-label={buyer.status === 'active' ? 'Deshabilitar' : 'Habilitar'}
+                                onClick={e => { e.stopPropagation(); handleToggleBuyerStatus(buyer.id); }}
                               >
-                                <IconDotsVertical />
+                                {buyer.status === 'active' ? <IconDisable /> : <IconEnable />}
                               </button>
-                              {buyerDesktopMenuOpen === buyer.id && (
-                                <div className={listStyles.desktopMenuDropdown} role="menu">
-                                  <button
-                                    type="button"
-                                    role="menuitem"
-                                    className={listStyles.desktopMenuItem}
-                                    onClick={() => { eventType === 'raffle' ? setRaffleDetailBuyer(buyer) : setPurchaseDetailBuyer(buyer); setBuyerDesktopMenuOpen(null); }}
-                                  >
-                                    <IconDetail /> Detalle
-                                  </button>
-                                  <button
-                                    type="button"
-                                    role="menuitem"
-                                    className={listStyles.desktopMenuItem}
-                                    onClick={() => { handleToggleBuyerStatus(buyer.id); setBuyerDesktopMenuOpen(null); }}
-                                  >
-                                    {buyer.status === 'active' ? <><IconDisable /> Deshabilitar</> : <><IconEnable /> Habilitar</>}
-                                  </button>
-                                </div>
-                              )}
                             </div>
                           </td>
                         </tr>
@@ -740,7 +608,7 @@ function EventDetailContent() {
               {/* Mobile list */}
               {!isDesktop && (
                 <div
-                  className={`${listStyles.mobileListContainer} ${selectedBuyers.length > 0 ? listStyles.hasStickyBar : ''}`}
+                  className={listStyles.mobileListContainer}
                   role="list"
                 >
                   {filteredBuyers.map(buyer => {
@@ -750,26 +618,8 @@ function EventDetailContent() {
                         key={buyer.id}
                         id={buyer.id}
                         isInactive={buyer.status === 'inactive'}
-                        isSelected={selectedBuyers.includes(buyer.id)}
-                        checkboxSlot={
-                          <input
-                            type="checkbox"
-                            id={`buyer-${buyer.id}`}
-                            checked={selectedBuyers.includes(buyer.id)}
-                            onChange={() => handleSelectBuyer(buyer.id)}
-                            disabled={buyer.status === 'inactive'}
-                            className={listStyles.mobileCheckbox}
-                            aria-label={`Seleccionar ${buyer.firstName} ${buyer.lastName}`}
-                          />
-                        }
-                        name={
-                          <span
-                            onClick={() => eventType === 'raffle' ? setRaffleDetailBuyer(buyer) : setPurchaseDetailBuyer(buyer)}
-                            style={{ cursor: 'pointer' }}
-                          >
-                            {buyer.firstName} {buyer.lastName}
-                          </span>
-                        }
+                        onClick={() => eventType === 'raffle' ? setRaffleDetailBuyer(buyer) : setPurchaseDetailBuyer(buyer)}
+                        name={<>{buyer.firstName} {buyer.lastName}</>}
                         phone={buyer.phone}
                         eventLine={
                           eventType === 'food_sale'
@@ -839,80 +689,65 @@ function EventDetailContent() {
           {/* ── CONFIGURACIÓN ────────────────────────────────────────────── */}
           {activeTopTab === 'configuracion' && (
             <div className={styles.configTab}>
-              <div className={styles.configSection}>
-                <EventDataStep
-                  key={eventData.id}
-                  ref={eventDataStepRef}
-                  readOnly={!isConfigEditing}
-                  prizesLocked={prizesLocked}
-                  allowDishClose={eventType === 'food_sale'}
-                  onDishCloseToggle={handleDishCloseToggle}
-                  initialData={{
-                    type: eventType,
-                    name: eventData.name,
-                    endDate: new Date(eventData.endDate),
-                    numberValue: String(eventData.ticketPrice),
-                    totalNumbers: String(eventData.totalNumbers),
-                    autoAdjust: false,
-                    prizes: [...(eventData.prizes ?? [])].sort((a, b) => a.position - b.position).map(p => p.description),
-                    foodItems: (eventData.dishes ?? []).map(d => ({ name: d.name, price: String(d.price), sold: d.sold, total: d.total })),
-                  }}
-                  onNext={() => setIsConfigEditing(false)}
-                  onBack={() => {}}
-                />
-              </div>
-
-              <div className={styles.configActions}>
-                {!isConfigEditing ? (
-                  <button className="btn btn-secondary btn-sm" onClick={() => setIsConfigEditing(true)}>
-                    Editar datos
-                  </button>
-                ) : (
-                  <>
-                    <button className="btn btn-primary btn-sm" onClick={() => eventDataStepRef.current?.validateAndNext()}>
-                      Guardar cambios
-                    </button>
-                    <button className="btn btn-secondary btn-sm" onClick={() => setIsConfigEditing(false)}>
-                      Cancelar
-                    </button>
-                  </>
-                )}
-              </div>
-
-              <div className={styles.dangerZone}>
-                <div className={styles.dangerZoneText}>
-                  <h3 className={styles.dangerZoneTitle}>Cancelar evento</h3>
-                  <p className={styles.dangerZoneDesc}>
-                    Cancelá el evento si no puede llevarse a cabo. Se registrará como cancelado y no se podrán agregar nuevas ventas.
-                  </p>
+              <div className={styles.tableContainer}>
+                <div className={styles.configSection}>
+                  <EventDataStep
+                    key={eventData.id}
+                    ref={eventDataStepRef}
+                    readOnly={!isConfigEditing}
+                    prizesLocked={prizesLocked}
+                    allowDishClose={eventType === 'food_sale'}
+                    onDishCloseToggle={handleDishCloseToggle}
+                    initialData={{
+                      type: eventType,
+                      name: eventData.name,
+                      endDate: new Date(eventData.endDate),
+                      numberValue: String(eventData.ticketPrice),
+                      totalNumbers: String(eventData.totalNumbers),
+                      autoAdjust: false,
+                      prizes: [...(eventData.prizes ?? [])].sort((a, b) => a.position - b.position).map(p => p.description),
+                      foodItems: (eventData.dishes ?? []).map(d => ({ name: d.name, price: String(d.price), sold: d.sold, total: d.total })),
+                    }}
+                    onNext={() => setIsConfigEditing(false)}
+                    onBack={() => {}}
+                  />
                 </div>
-                <button className={styles.dangerBtn} onClick={() => setIsCloseEventOpen(true)}>
-                  Cancelar
-                </button>
+                <div className={styles.configActions}>
+                  {!isConfigEditing ? (
+                    <button className="btn btn-secondary btn-sm" onClick={() => setIsConfigEditing(true)}>
+                      Editar datos
+                    </button>
+                  ) : (
+                    <>
+                      <button className="btn btn-primary btn-sm" onClick={() => eventDataStepRef.current?.validateAndNext()}>
+                        Guardar cambios
+                      </button>
+                      <button className="btn btn-secondary btn-sm" onClick={() => setIsConfigEditing(false)}>
+                        Cancelar
+                      </button>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              <div className={styles.tableContainer}>
+                <div className={styles.dangerZone}>
+                  <div className={styles.dangerZoneText}>
+                    <h3 className={styles.dangerZoneTitle}>Cancelar evento</h3>
+                    <p className={styles.dangerZoneDesc}>
+                      Cancelá el evento si no puede llevarse a cabo. Se registrará como cancelado y no se podrán agregar nuevas ventas.
+                    </p>
+                  </div>
+                  <button className={styles.dangerBtn} onClick={() => setIsCloseEventOpen(true)}>
+                    Cancelar
+                  </button>
+                </div>
               </div>
             </div>
           )}
 
         </div>
       </div>
-
-      {/* Compradores: Mobile sticky action bar */}
-      <MobileStickyActionBar
-        visible={!isDesktop && activeTopTab === 'compradores' && selectedBuyers.length > 0}
-        onCancel={() => setSelectedBuyers([])}
-      >
-        {selectionType === 'raffle' && (
-          <button type="button" className={listStyles.assignStickyPrimary} onClick={() => handlePrintReceipts(!areAllSelectedPrinted)}>
-            {areAllSelectedPrinted ? `Desmarcar impreso (${selectedBuyers.length})` : `Imprimir comprobantes (${selectedBuyers.length})`}
-          </button>
-        )}
-        {selectionType === 'food_sale' && (
-          <button type="button" className={listStyles.assignStickyPrimary} onClick={() => handleSetDeliveredStatus(!areAllSelectedDelivered)}>
-            {areAllSelectedDelivered ? `Desmarcar (${selectedBuyers.length})` : `Entregado (${selectedBuyers.length})`}
-          </button>
-        )}
-      </MobileStickyActionBar>
-
 
       {/* Compradores: Modal detalle de números — rifa (desktop) */}
       {isDesktop && raffleDetailBuyer && (
@@ -1109,26 +944,113 @@ function EventDetailContent() {
         </div>
       )}
 
-      {/* Vendedores: Mobile sticky bars */}
-      {activeTopTab === 'vendedores' && activeVendorTab === 'pending' && selectedVendors.length > 0 && (
-        <div className={styles.assignStickyBar}>
-          <button className={styles.assignStickyCancel} onClick={() => setSelectedVendors([])}>Cancelar</button>
-          <button className={styles.assignStickyPrimary} onClick={handleMarkAsPaid}>Cobrado</button>
-        </div>
-      )}
-      {activeTopTab === 'vendedores' && activeVendorTab === 'collected' && selectedCollectedVendors.length > 0 && (
-        <div className={styles.assignStickyBar}>
-          <button className={styles.assignStickyPrimary} onClick={handleAssignMoreNumbers}>Asignar más números</button>
-        </div>
-      )}
+      {/* Vendedores: Modal detalle de vendedor (desktop) */}
+      {isDesktop && vendorDetailItem && (() => {
+        const isCollected = collectedData.some(v => v.id === vendorDetailItem.id);
+        return (
+          <div className={buyerStyles.modalOverlay} onClick={() => setVendorDetailItem(null)}>
+            <div className={buyerStyles.purchaseDetailModal} onClick={e => e.stopPropagation()}>
+              <div className={buyerStyles.purchaseDetailHeader}>
+                <div>
+                  <h2 className={buyerStyles.purchaseDetailTitle}>{vendorDetailItem.name}</h2>
+                  <div className={buyerStyles.detailBuyerMeta}>
+                    <span>{vendorDetailItem.sold} de {vendorDetailItem.total} vendidos</span>
+                  </div>
+                </div>
+                <button className={buyerStyles.closeButton} onClick={() => setVendorDetailItem(null)}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                    <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </button>
+              </div>
+              <div className={buyerStyles.detailStatusRow}>
+                <span className={`${buyerStyles.detailStatusBadge} ${isCollected ? buyerStyles.detailStatusDelivered : buyerStyles.detailStatusPending}`}>
+                  <span className={buyerStyles.detailStatusDot} />
+                  {isCollected ? 'Cobrado' : 'Por cobrar'}
+                </span>
+              </div>
+              <div className={buyerStyles.detailDivider} />
+              <div className={buyerStyles.detailItemList}>
+                <div className={buyerStyles.detailItemRow}>
+                  <span className={buyerStyles.detailItemName}>Números vendidos</span>
+                  <span className={buyerStyles.detailItemSubtotal}>{vendorDetailItem.sold} / {vendorDetailItem.total}</span>
+                </div>
+                <div className={buyerStyles.detailItemRow}>
+                  <span className={buyerStyles.detailItemName}>Porcentaje</span>
+                  <span className={buyerStyles.detailItemSubtotal}>{vendorDetailItem.percentage}%</span>
+                </div>
+              </div>
+              <div className={buyerStyles.detailDivider} />
+              <div className={buyerStyles.detailTotalRow}>
+                <span className={buyerStyles.detailTotalLabel}>Total</span>
+                <span className={buyerStyles.detailTotalValue}>${vendorDetailItem.amount.toLocaleString('es-AR')}</span>
+              </div>
+              <div className={buyerStyles.purchaseDetailFooter}>
+                <button
+                  className="btn btn-primary"
+                  onClick={() => handleToggleVendorCobrado(vendorDetailItem)}
+                >
+                  {isCollected ? 'Desmarcar cobrado' : 'Marcar como cobrado'}
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
 
-      {/* Assign Numbers Modal */}
-      <AssignNumbersModal
-        isOpen={isAssignModalOpen}
-        vendorNames={collectedData.filter(v => selectedCollectedVendors.includes(v.id)).map(v => v.name)}
-        onClose={() => setIsAssignModalOpen(false)}
-        onConfirm={handleModalConfirm}
-      />
+      {/* Vendedores: Bottom sheet detalle de vendedor (mobile) */}
+      {(() => {
+        const isCollected = vendorDetailItem ? collectedData.some(v => v.id === vendorDetailItem.id) : false;
+        return (
+          <BottomSheet
+            isOpen={!isDesktop && !!vendorDetailItem}
+            onClose={() => setVendorDetailItem(null)}
+            label="Detalle de vendedor"
+            title={vendorDetailItem?.name ?? ''}
+            subtitle={vendorDetailItem ? `${vendorDetailItem.sold} de ${vendorDetailItem.total} vendidos` : ''}
+            showCloseButton
+            footer={
+              <button
+                className="btn btn-primary btn-full"
+                onClick={() => vendorDetailItem && handleToggleVendorCobrado(vendorDetailItem)}
+              >
+                {isCollected ? 'Desmarcar cobrado' : 'Marcar como cobrado'}
+              </button>
+            }
+          >
+            <div style={{ paddingBottom: 'var(--space-md)' }}>
+              <span className={`${buyerStyles.detailStatusBadge} ${isCollected ? buyerStyles.detailStatusDelivered : buyerStyles.detailStatusPending}`}>
+                <span className={buyerStyles.detailStatusDot} />
+                {isCollected ? 'Cobrado' : 'Por cobrar'}
+              </span>
+            </div>
+            <div className={buyerStyles.detailDivider} style={{ margin: '0 calc(-1 * var(--space-lg))' }} />
+            <div style={{ padding: '4px 0 8px' }}>
+              <div className={buyerStyles.detailItemRow}>
+                <span className={buyerStyles.detailItemName}>Números vendidos</span>
+                <span className={buyerStyles.detailItemSubtotal}>{vendorDetailItem?.sold} / {vendorDetailItem?.total}</span>
+              </div>
+              <div className={buyerStyles.detailItemRow}>
+                <span className={buyerStyles.detailItemName}>Porcentaje</span>
+                <span className={buyerStyles.detailItemSubtotal}>{vendorDetailItem?.percentage}%</span>
+              </div>
+            </div>
+            <div className={buyerStyles.detailDivider} style={{ margin: '0 calc(-1 * var(--space-lg))' }} />
+            <div className={buyerStyles.detailTotalRow} style={{ padding: 'var(--space-md) 0 0' }}>
+              <span className={buyerStyles.detailTotalLabel}>Total</span>
+              <span className={buyerStyles.detailTotalValue}>${vendorDetailItem?.amount.toLocaleString('es-AR')}</span>
+            </div>
+          </BottomSheet>
+        );
+      })()}
+
+      {/* Vendedores: Snackbar cobrado */}
+      {vendorSnackbar.isVisible && (
+        <div className={`${buyerStyles.snackbar} ${vendorSnackbar.isClosing ? buyerStyles.snackbarClosing : ''}`}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M22 4L12 14.01L9 11.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>
+          Estado de cobro actualizado
+        </div>
+      )}
 
       {/* Register Sale — mobile bottom button */}
       <div className={styles.registerSaleBottomBar}>

--- a/src/components/EventCard/EventCard.module.css
+++ b/src/components/EventCard/EventCard.module.css
@@ -123,7 +123,7 @@
 }
 
 .progressCancelled {
-  display: none;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .progressMeta {

--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -103,30 +103,28 @@ export default function EventCard({
         {/* Title */}
         <h2 className={styles.title}>{name}</h2>
 
-        {/* Progress — hidden for cancelled */}
-        {status !== 'cancelled' && (
-          <div className={styles.progressBlock}>
-            <div className={styles.progressTrack}>
-              <div
-                className={`${styles.progressFill} ${progressBarClass}`}
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-            <div className={styles.progressMeta}>
-              {type === 'raffle' ? (
-                <span>{soldUnits}/{totalUnits} vendidos</span>
-              ) : (
-                <span>{Math.round(progress)}% vendido</span>
-              )}
-              {status === 'completed' && goalReached && (
-                <span className={styles.goalReached}>Meta alcanzada ✓</span>
-              )}
-            </div>
+        {/* Progress */}
+        <div className={styles.progressBlock}>
+          <div className={styles.progressTrack}>
+            <div
+              className={`${styles.progressFill} ${progressBarClass}`}
+              style={{ width: `${progress}%` }}
+            />
           </div>
-        )}
+          <div className={styles.progressMeta}>
+            {type === 'raffle' ? (
+              <span>{soldUnits}/{totalUnits} vendidos</span>
+            ) : (
+              <span>{Math.round(progress)}% vendido</span>
+            )}
+            {status === 'completed' && goalReached && (
+              <span className={styles.goalReached}>Meta alcanzada ✓</span>
+            )}
+          </div>
+        </div>
 
         {/* Footer */}
-        <div className={`${styles.footer} ${status === 'cancelled' ? styles.footerCancelled : ''}`}>
+        <div className={styles.footer}>
           <span className={styles.footerLeft}>Recaudado {fmt(collected)}</span>
           {status === 'cancelled' ? (
             <span className={styles.footerRight}>Meta {fmt(goal)}</span>

--- a/src/components/MobileListRow/index.tsx
+++ b/src/components/MobileListRow/index.tsx
@@ -5,7 +5,7 @@ interface MobileListRowProps {
   id: string;
   isInactive?: boolean;
   isSelected?: boolean;
-  checkboxSlot: React.ReactNode;
+  checkboxSlot?: React.ReactNode;
   /** Content rendered inside the <h3> name element */
   name: React.ReactNode;
   phone: string;
@@ -13,6 +13,7 @@ interface MobileListRowProps {
   sellerLine?: string;
   /** Full menu: button + dropdown (use mobileMenuContainer/mobileMenuButton/mobileMenuDropdown/mobileMenuItem from list.module.css) */
   menuSlot: React.ReactNode;
+  onClick?: () => void;
 }
 
 export default function MobileListRow({
@@ -25,6 +26,7 @@ export default function MobileListRow({
   eventLine,
   sellerLine,
   menuSlot,
+  onClick,
 }: MobileListRowProps) {
   return (
     <article
@@ -33,9 +35,11 @@ export default function MobileListRow({
         styles.mobileListRow,
         isInactive ? styles.mobileRowInactive : '',
         isSelected ? styles.mobileRowSelected : '',
+        onClick ? styles.mobileRowClickable : '',
       ].filter(Boolean).join(' ')}
+      onClick={onClick}
     >
-      <div className={styles.mobileRowCheckbox}>{checkboxSlot}</div>
+      {checkboxSlot && <div className={styles.mobileRowCheckbox}>{checkboxSlot}</div>}
       <div className={styles.mobileRowMain}>
         <div className={styles.mobileRowTop}>
           <h3 className={styles.mobileRowName}>{name}</h3>

--- a/src/components/wizard/EventDataStep.tsx
+++ b/src/components/wizard/EventDataStep.tsx
@@ -58,6 +58,7 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
     const eventType = initialData?.type || 'raffle';
     const isFoodSale = eventType === 'food_sale';
     const creationDate: Date = (initialData?.startDate instanceof Date ? initialData.startDate : new Date());
+    const initialFoodItemCount = initialData?.foodItems?.length ?? 0;
 
     const [formData, setFormData] = useState({
       name: initialData?.name || '',
@@ -154,7 +155,8 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
     };
 
     const handleRemoveFoodItem = (index: number) => {
-      if (formData.foodItems.length > 1) setFormData(prev => ({ ...prev, foodItems: prev.foodItems.filter((_, i) => i !== index) }));
+      if (index < initialFoodItemCount) return;
+      setFormData(prev => ({ ...prev, foodItems: prev.foodItems.filter((_, i) => i !== index) }));
     };
 
     const handleDishCloseToggle = (index: number) => {
@@ -189,9 +191,12 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
         <div className={styles.datesCard}>
           <div className={styles.fieldGroup}>
             <label className={styles.fieldLabel}>Fecha de inicio</label>
-            <div className={styles.startDateDisplay}>
-              {formData.startDate.toLocaleDateString('es-AR', { day: '2-digit', month: '2-digit', year: 'numeric' })}
-            </div>
+            <DatePicker
+              selected={formData.startDate}
+              onChange={(date) => handleInputChange('startDate', date)}
+              placeholder="dd/mm/aa"
+              disabled={readOnly}
+            />
           </div>
           <div className={styles.fieldGroup}>
             <label className={styles.fieldLabel}>Fecha de fin</label>
@@ -339,28 +344,40 @@ const EventDataStep = forwardRef<EventDataStepRef, EventDataStepProps>(
                   </div>
                 ) : (
                   /* Vista de edición: inputs */
-                  <div className={styles.foodRowFields}>
-                    <div className={styles.foodNameField}>
-                      <input
-                        type="text"
-                        value={item.name}
-                        onChange={(e) => handleFoodItemChange(index, 'name', e.target.value)}
-                        className={`${styles.input} ${errors[`foodItem_${index}_name`] ? styles.inputError : ''}`}
-                        placeholder={index === 0 ? 'Ej: Pollo asado con papas' : 'Nombre del plato'}
-                      />
-                      {errors[`foodItem_${index}_name`] && <span className={styles.errorText}>{errors[`foodItem_${index}_name`]}</span>}
+                  <>
+                    <div className={styles.foodRowFields}>
+                      <div className={styles.foodNameField}>
+                        <input
+                          type="text"
+                          value={item.name}
+                          onChange={(e) => handleFoodItemChange(index, 'name', e.target.value)}
+                          className={`${styles.input} ${errors[`foodItem_${index}_name`] ? styles.inputError : ''}`}
+                          placeholder={index === 0 ? 'Ej: Pollo asado con papas' : 'Nombre del plato'}
+                        />
+                        {errors[`foodItem_${index}_name`] && <span className={styles.errorText}>{errors[`foodItem_${index}_name`]}</span>}
+                      </div>
+                      <div className={styles.foodPriceField}>
+                        <input
+                          type="text"
+                          value={item.price}
+                          onChange={(e) => handleFoodItemChange(index, 'price', e.target.value)}
+                          className={`${styles.input} ${errors[`foodItem_${index}_price`] ? styles.inputError : ''}`}
+                          placeholder="$0"
+                        />
+                        {errors[`foodItem_${index}_price`] && <span className={styles.errorText}>{errors[`foodItem_${index}_price`]}</span>}
+                      </div>
                     </div>
-                    <div className={styles.foodPriceField}>
-                      <input
-                        type="text"
-                        value={item.price}
-                        onChange={(e) => handleFoodItemChange(index, 'price', e.target.value)}
-                        className={`${styles.input} ${errors[`foodItem_${index}_price`] ? styles.inputError : ''}`}
-                        placeholder="$0"
-                      />
-                      {errors[`foodItem_${index}_price`] && <span className={styles.errorText}>{errors[`foodItem_${index}_price`]}</span>}
-                    </div>
-                  </div>
+                    {index >= initialFoodItemCount && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveFoodItem(index)}
+                        className={styles.removeBtn}
+                        aria-label="Eliminar plato"
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    )}
+                  </>
                 )}
                 {allowDishClose && (
                   <button

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -197,24 +197,36 @@ const generateBuyers = (): Buyer[] => {
     buyerId++;
   }
 
-  // 320 compradores para VENTA DE COMIDA (evento 2)
-  const foodDishes = [
-    { dishName: 'Milanesa con papas', unitPrice: 2500 },
-    { dishName: 'Empanadas (docena)', unitPrice: 3000 },
-  ];
-  for (let i = 0; i < 320; i++) {
+  // 185 compradores para VENTA DE COMIDA (evento 2)
+  // Distribución determinista alineada con los sold de cada plato:
+  // Milanesa: 45 | Empanadas: 30 | Asado: 18 | Pollo: 22 | Choripán: 55 | Torta: 40
+  const MI = { dishName: 'Milanesa napolitana con papas fritas', unitPrice: 2500 };
+  const EM = { dishName: 'Empanadas (docena)',                   unitPrice: 3000 };
+  const AS = { dishName: 'Asado con ensalada mixta',             unitPrice: 4500 };
+  const PO = { dishName: 'Pollo al horno con guarnición',        unitPrice: 3200 };
+  const CH = { dishName: 'Choripán completo',                    unitPrice: 1500 };
+  const TO = { dishName: 'Torta casera (porción)',               unitPrice:  800 };
+
+  // Plan de compras por comprador (cada ítem = qty 1)
+  // Milanesa: 40 + 5 = 45 | Torta: 5 + 20 + 15 = 40 | Choripán: 35 + 20 = 55
+  const purchasePlan: Array<typeof MI[]> = [
+    ...Array(40).fill([MI]),        // 40 → solo milanesa
+    ...Array(5).fill([MI, TO]),     //  5 → milanesa + torta
+    ...Array(30).fill([EM]),        // 30 → solo empanadas
+    ...Array(18).fill([AS]),        // 18 → solo asado
+    ...Array(22).fill([PO]),        // 22 → solo pollo
+    ...Array(35).fill([CH]),        // 35 → solo choripán
+    ...Array(20).fill([CH, TO]),    // 20 → choripán + torta
+    ...Array(15).fill([TO]),        // 15 → solo torta
+  ]; // total: 185 compradores
+
+  for (let i = 0; i < purchasePlan.length; i++) {
     const firstName = firstNames[Math.floor(Math.random() * firstNames.length)];
     const lastName = lastNames[Math.floor(Math.random() * lastNames.length)];
     const phone = `3584${String(100000 + buyerId).padStart(6, '0')}`;
     const isActive = Math.random() > 0.1; // 90% activos
 
-    // Generar detalle de compra aleatorio
-    const foodPurchase = foodDishes
-      .filter(() => Math.random() > 0.3)
-      .map(dish => ({ ...dish, quantity: Math.floor(Math.random() * 4) + 1 }));
-    const finalPurchase = foodPurchase.length > 0
-      ? foodPurchase
-      : [{ ...foodDishes[Math.floor(Math.random() * foodDishes.length)], quantity: 1 }];
+    const finalPurchase = purchasePlan[i].map(d => ({ ...d, quantity: 1 }));
 
     const seller = pickSellerForEvent('2');
     buyers.push({

--- a/src/styles/list.module.css
+++ b/src/styles/list.module.css
@@ -410,9 +410,7 @@
   padding: 16px;
 }
 
-/* Checkbox — fixed width, 20px left edge margin */
-.table th:nth-child(1),
-.tableRow td:nth-child(1),
+/* Checkbox — fixed width (kept for backwards compat if class is used directly) */
 .table th.checkboxColumn,
 .tableRow td.checkboxColumn {
   width: 56px !important;
@@ -424,6 +422,8 @@
 }
 
 /* Content columns — no explicit width, table-layout:fixed distributes evenly */
+.table th:nth-child(1),
+.tableRow td:nth-child(1),
 .table th:nth-child(2),
 .tableRow td:nth-child(2),
 .table th:nth-child(3),
@@ -520,6 +520,21 @@
   text-align: center;
   overflow: visible !important;
   position: relative;
+}
+
+.inlineActionsCell {
+  vertical-align: middle !important;
+  padding: 8px 16px !important;
+  white-space: nowrap;
+  overflow: visible !important;
+  width: 1%;
+}
+
+.inlineActionsCell > div {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  align-items: center;
 }
 
 /* ─── Desktop Context Menu ───────────────────────────────────────────────── */
@@ -720,6 +735,10 @@
 
 .mobileRowSelected:hover {
   background: var(--color-bg-tertiary);
+}
+
+.mobileRowClickable {
+  cursor: pointer;
 }
 
 .mobileRowInactive {


### PR DESCRIPTION
## Summary

- **Compradores**: elimina checkboxes, filas clickeables con modal de detalle, botones inline deshabilitar/habilitar, vendedor como tercera línea, botón imprimir solo en tab "No impreso"
- **Vendedores**: elimina checkboxes, filas clickeables con bottom sheet de detalle y acción "Marcar como cobrado", hover y tipografía consistente con compradores
- **Panel de métricas**: barra de progreso llega al borde de la card, estado sin días restantes, platos en 2 columnas con divisor vertical en desktop
- **EventCard cancelado**: muestra barra de progreso (fill gris muted) en lugar de ocultarla
- **EventDataStep**: fecha de inicio reemplazada por DatePicker, platos nuevos en edición tienen botón eliminar (originales bloqueados)
- **Mock data**: compradores de venta de comida deterministas y alineados con las cantidades vendidas por plato

## Test plan

- [ ] Verificar que compradores de rifa y venta de comida abren modal al hacer click en la fila
- [ ] Verificar que el botón "Imprimir comprobante" no aparece en la tab "Impreso"
- [ ] Verificar que vendedores abre bottom sheet y permite marcar como cobrado/pendiente
- [ ] Verificar barra de progreso llega al borde en el panel de métricas (food_sale y raffle)
- [ ] Verificar que platos se muestran en 2 columnas con divisor en desktop
- [ ] Verificar que EventCard con status "cancelled" muestra la barra de progreso
- [ ] Verificar que en edición de evento food_sale solo los platos nuevos tienen botón eliminar

🤖 Generated with [Claude Code](https://claude.com/claude-code)